### PR TITLE
Fixed up various one-off discrepencies (e.g. whitespace, shebang)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,13 +1,13 @@
-var grunt = require('grunt');
+module.exports = function (grunt) {
+  grunt.loadNpmTasks('grunt-node-webkit-builder');
 
-grunt.loadNpmTasks('grunt-node-webkit-builder');
-
-grunt.initConfig({
-  nodewebkit: {
-    options: {
-        platforms: ['linux64'],
-        buildDir: './webkitbuilds', // Where the build version of my node-webkit app is saved
+  grunt.initConfig({
+    nodewebkit: {
+      options: {
+          platforms: ['linux64'],
+          buildDir: './webkitbuilds', // Where the build version of my node-webkit app is saved
+      },
+      src: ['./app/**/*'] // Your node-webkit app
     },
-    src: ['./app/**/*'] // Your node-webkit app
-  },
-})
+  });
+};

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -1,4 +1,4 @@
-html,body,iframe {
+html, body, iframe {
 	width: 100%;
 	height: 100%;
 	padding: 0;

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -1,17 +1,16 @@
-(function(gui,urllib,pkg) {
+(function (gui, urllib, pkg) {
 	'use strict';
 	var win = gui.Window.get();
 	var validSlackRedirect = /(.+\.)?slack-redir.com/i;
 
-	win.on('new-win-policy',function (frame, url, policy) {
+	win.on('new-win-policy', function (frame, url, policy) {
 		var openRequest = urllib.parse(url);
 
-		if ( validSlackRedirect.test(openRequest.host)) {
+		if (validSlackRedirect.test(openRequest.host)) {
 			gui.Shell.openExternal(url);
 			policy.ignore();
-			console.log('Allowing browser to handle: '+ JSON.stringify(openRequest));
+			console.log('Allowing browser to handle: ' + JSON.stringify(openRequest));
 		}
-		
 	});
 
 	var isMinimized = false;
@@ -49,4 +48,4 @@
 		}
 	}));
 	tray.menu = trayMenu;
-})(require('nw.gui'),require('url'),require('../package.json'));
+})(require('nw.gui'), require('url'), require('../package.json'));

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/env sh
 ./node_modules/.bin/grunt nodewebkit

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
   "name": "slack-for-linux",
   "version": "1.1.1",
-  "description": "",
-  "keywords": [],
+  "description": "Slack client for linux",
+  "keywords": [
+    "slack",
+    "linux",
+    "node-webkit"
+  ],
   "homepage": "https://github.com/wlaurance/slack-for-linux",
   "bugs": "https://github.com/wlaurance/slack-for-linux/issues",
   "author": {


### PR DESCRIPTION
Since I have push access, I wanted to visit all the discrepencies I saw earlier. In this PR:
- Moved to standard `Gruntfile` format
  - Normally we use `module.exports = function (grunt) {` for inversion of control during testing
  - http://gruntjs.com/getting-started#an-example-gruntfile
- Moved to `/usr/bin/env` for `install.sh` shebang
  - While it is unlikely that `/usr/sh` will be defined elsewhere, it is a common pattern (and consistent with this other project shebangs) to use `/usr/bin/env` to resolve its location
- Added missing whitespace in CSS (was inconsistent with JS spacing)
- Added missing whitespace in JS parameters (was inconsistent -- some had spaces after commas, others didn't)
- Removed trailing whitespace (was inconsistent as other lines did not have trailing whitespace)
- Added description and keywords (useful for searching on `npm`)
