### PR TITLE
Added test script

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,4 +10,4 @@ grunt.initConfig({
     },
     src: ['./app/**/*'] // Your node-webkit app
   },
-})
+});

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "linux"
   ],
   "scripts": {
-    "postinstall": "./install.sh"
+    "postinstall": "./install.sh",
+    "test": "jshint *.js app/"
   },
   "bin": {
     "slack-for-linux": "./run.js"

--- a/run.js
+++ b/run.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 var spawn = require('child_process').spawn;
 
-var slack = spawn(__dirname + "/./webkitbuilds/slack4linux/linux64/slack4linux");
+spawn(__dirname + '/./webkitbuilds/slack4linux/linux64/slack4linux');
 
 


### PR DESCRIPTION
We had a JSHint setup but it was not being enforced. In this PR:
- Added `test` script to run JSHint against `app/` (recurses all files) and any `.js` file in root
- Fixed up JSHint errors
