### PR TITLE
Added jscs for style checking

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,72 @@
+{
+  "requireCurlyBraces": true,
+  "requireSpaceBeforeKeywords": [
+      "else",
+      "while",
+      "catch"
+  ],
+  "requireSpaceAfterKeywords": [
+    "do",
+    "for",
+    "if",
+    "else",
+    "switch",
+    "case",
+    "try",
+    "catch",
+    "void",
+    "while",
+    "with",
+    "return",
+    "typeof",
+    "function"
+  ],
+  "requireSpaceBeforeBlockStatements": true,
+  "requireParenthesesAroundIIFE": true,
+  "requireSpacesInConditionalExpression": true,
+  "requireSpacesInFunctionExpression": {
+      "beforeOpeningRoundBrace": true,
+      "beforeOpeningCurlyBrace": true
+  },
+  "requireSpacesInAnonymousFunctionExpression": {
+    "beforeOpeningRoundBrace": true,
+    "beforeOpeningCurlyBrace": true
+  },
+  "requireSpacesInNamedFunctionExpression": {
+      "beforeOpeningRoundBrace": true,
+      "beforeOpeningCurlyBrace": true
+  },
+  "requireSpacesInFunctionDeclaration": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "disallowSpacesInFunctionDeclaration": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInCallExpression": true,
+  "disallowMultipleVarDecl": "exceptUndefined",
+  "requireBlocksOnNewline": 1,
+  "disallowPaddingNewlinesInBlocks": true,
+  "disallowSpacesInsideObjectBrackets": "all",
+  "disallowSpacesInsideArrayBrackets": "all",
+  "disallowSpacesInsideParentheses": true,
+  "disallowQuotedKeysInObjects": "allButReserved",
+  "disallowSpaceAfterObjectKeys": true,
+  "requireSpaceBeforeObjectValues": true,
+  "requireCommaBeforeLineBreak": true,
+  "disallowSpaceAfterPrefixUnaryOperators": true,
+  "requireSpaceBeforeBinaryOperators": true,
+  "requireSpaceAfterBinaryOperators": true,
+  "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
+  "disallowMultipleLineBreaks": true,
+  "disallowMixedSpacesAndTabs": true,
+  "disallowTrailingWhitespace": true,
+  "disallowTrailingComma": true,
+  "disallowKeywordsOnNewLine": ["else"],
+  "requireLineFeedAtFileEnd": true,
+  "disallowNewlineBeforeBlockStatements": true,
+  "validateLineBreaks": "LF",
+  "validateQuoteMarks": "'",
+  "validateIndentation": "\t",
+  "validateParameterSeparator": ", ",
+  "requireSpaceBetweenArguments": true
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,6 +5,7 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-node-webkit-builder');
 	try {
 		grunt.loadNpmTasks('grunt-contrib-jshint');
+		grunt.loadNpmTasks('grunt-jscs');
 		grunt.loadNpmTasks('grunt-lintspaces');
 	} catch (err) {
 	}
@@ -18,8 +19,14 @@ module.exports = function (grunt) {
 			src: ['./app/**/*'] // Your node-webkit app
 		},
 		jshint: {
-			jshintrc: '.jshintrc',
-			all: ['*.js', 'app/**/*.js']
+			all: ['*.js', 'app/**/*.js'],
+			jshintrc: '.jshintrc'
+		},
+		jscs: {
+			all: '<%= jshint.all %>',
+			options: {
+				config: '.jscsrc'
+			}
 		},
 		lintspaces: {
 			src: ['*', 'app/**/*', '!**/*.png'],
@@ -29,5 +36,5 @@ module.exports = function (grunt) {
 		}
 	});
 
-	grunt.registerTask('lint', ['jshint', 'lintspaces']);
+	grunt.registerTask('lint', ['jshint', 'jscs', 'lintspaces']);
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "grunt-contrib-jshint": "^0.10.0",
+    "grunt-jscs": "^1.1.0",
     "grunt-lintspaces": "^0.6.0"
   }
 }


### PR DESCRIPTION
**Depends on #10**

PR #11 was inconsistent with the styles in the rest of the repo. By not having consistently styled code, contributors take longer to decide how to format their code and the overall readability of the repo suffers. I have decided to add `jscs` to mitigate the issue.

https://github.com/jscs-dev/node-jscs

In this PR:
- Added `grunt-jscs` and `.jscsrc`
