### PR TITLE
Added the --minimize-to-tray command line option.

### DIFF
--- a/app/js/index.js
+++ b/app/js/index.js
@@ -27,6 +27,7 @@
 	var argv = ['nw', pkg.name].concat(gui.App.argv);
 	program
 		.version(pkg.version)
+		.option('--minimize-to-tray')
 		.parse(argv);
 
 	win.on('new-win-policy', function (frame, urlStr, policy) {
@@ -50,18 +51,42 @@
 		console.log('Allowing browser to handle: ' + JSON.stringify(openRequest));
 	});
 
-	var isMinimized = false;
+	var isHidden = false;
+
+	win.on('hide', function () {
+		isHidden = true;
+	});
 	win.on('minimize', function () {
-		isMinimized = true;
+		isHidden = true;
+	});
+	win.on('show', function () {
+		isHidden = false;
 	});
 	win.on('restore', function () {
-		isMinimized = false;
+		isHidden = false;
 	});
+
+	var windowShowCommand = program.minimizeToTray ? 'show' : 'restore';
+	var windowHideCommand = program.minimizeToTray ? 'hide' : 'minimize';
+
+	function showWindow() {
+		win[windowShowCommand]();
+		isHidden = false;
+	};
+	function hideWindow() {
+		win[windowHideCommand]();
+		isHidden = true;
+	};
+
+  gui.App.on('open', function (cmdline) {
+		showWindow();
+  });
+
 	function toggleVisibility() {
-		if (isMinimized) {
-			win.restore();
+		if (isHidden) {
+			showWindow();
 		} else {
-			win.minimize();
+			hideWindow();
 		}
 	}
 


### PR DESCRIPTION
If the `--minimize-to-tray` option is set, clicking on the tray icon will toggle `hide` / `show` thus the minimized window won't be visible in the task bar / window list.