### PR TITLE
Added the --close-to-tray command line option.

### DIFF
--- a/app/js/index.js
+++ b/app/js/index.js
@@ -27,6 +27,7 @@
 	var argv = ['nw', pkg.name].concat(gui.App.argv);
 	program
 		.version(pkg.version)
+		.option('--minimize-to-tray')
 		.parse(argv);
 
 	win.on('new-win-policy', function (frame, urlStr, policy) {
@@ -50,18 +51,42 @@
 		console.log('Allowing browser to handle: ' + JSON.stringify(openRequest));
 	});
 
-	var isMinimized = false;
+	var isHidden = false;
+
+	win.on('hide', function () {
+		isHidden = true;
+	});
 	win.on('minimize', function () {
-		isMinimized = true;
+		isHidden = true;
+	});
+	win.on('show', function () {
+		isHidden = false;
 	});
 	win.on('restore', function () {
-		isMinimized = false;
+		isHidden = false;
 	});
+
+	var windowShowCommand = program.minimizeToTray ? 'show' : 'restore';
+	var windowHideCommand = program.minimizeToTray ? 'hide' : 'minimize';
+
+	function showWindow() {
+		win[windowShowCommand]();
+		isHidden = false;
+	};
+	function hideWindow() {
+		win[windowHideCommand]();
+		isHidden = true;
+	};
+
+  gui.App.on('open', function (cmdline) {
+		showWindow();
+  });
+
 	function toggleVisibility() {
-		if (isMinimized) {
-			win.restore();
+		if (isHidden) {
+			showWindow();
 		} else {
-			win.minimize();
+			hideWindow();
 		}
 	}
 

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -28,6 +28,7 @@
 	program
 		.version(pkg.version)
 		.option('--minimize-to-tray')
+		.option('--close-to-tray')
 		.parse(argv);
 
 	win.on('new-win-policy', function (frame, urlStr, policy) {
@@ -66,8 +67,9 @@
 		isHidden = false;
 	});
 
-	var windowShowCommand = program.minimizeToTray ? 'show' : 'restore';
-	var windowHideCommand = program.minimizeToTray ? 'hide' : 'minimize';
+	var hideWanted = program.minimizeToTray || program.closeToTray;
+	var windowShowCommand = hideWanted ? 'show' : 'restore';
+	var windowHideCommand = hideWanted ? 'hide' : 'minimize';
 
 	function showWindow() {
 		win[windowShowCommand]();
@@ -81,6 +83,10 @@
   gui.App.on('open', function (cmdline) {
 		showWindow();
   });
+
+  if (program.closeToTray) {
+		win.on('close', hideWindow);
+  }
 
 	function toggleVisibility() {
 		if (isHidden) {


### PR DESCRIPTION
If the ~~` --keep-alive`~~ `--close-to-tray` command line option is set, clicking on the `close` button won't kill the application, it will only hide the window.