### PR TITLE
Updated all references from slack-for-linux to plaidchat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,49 +1,49 @@
-## slack-for-linux changelog
+## plaidchat changelog
 
 ### v1.6.3 (2015/06/11 06:03 +00:00)
-- [#78](https://github.com/slack-for-linux/slack-for-linux/pull/78) Added license information (@twolfson)
+- [#78](https://github.com/plaidchat/plaidchat/pull/78) Added license information (@twolfson)
 
 ### v1.6.1 (2015/06/10 08:02 +00:00)
-- [#74](https://github.com/slack-for-linux/slack-for-linux/pull/74) Fix notification audio (@bronzdoc)
+- [#74](https://github.com/plaidchat/plaidchat/pull/74) Fix notification audio (@bronzdoc)
 
 ### v1.5.2 (2015/06/08 21:51 +00:00)
-- [#73](https://github.com/slack-for-linux/slack-for-linux/pull/73) Add trailing newline character after github-changes (@wlaurance)
+- [#73](https://github.com/plaidchat/plaidchat/pull/73) Add trailing newline character after github-changes (@wlaurance)
 
 ### v1.5.1 (2015/06/08 21:27 +00:00)
-- [#72](https://github.com/slack-for-linux/slack-for-linux/pull/72) Added release script (@twolfson)
-- [#70](https://github.com/slack-for-linux/slack-for-linux/pull/70) Fixed up lint errors (@twolfson)
+- [#72](https://github.com/plaidchat/plaidchat/pull/72) Added release script (@twolfson)
+- [#70](https://github.com/plaidchat/plaidchat/pull/70) Fixed up lint errors (@twolfson)
 
 ### v1.5.0 (2015/06/02 23:17 +00:00)
-- [#64](https://github.com/slack-for-linux/slack-for-linux/pull/64) Added argument passing to slack-for-linux (@twolfson)
-- [#67](https://github.com/slack-for-linux/slack-for-linux/pull/67) Added CONTRIBUTING.md (@twolfson)
-- [#63](https://github.com/slack-for-linux/slack-for-linux/pull/63) Remove line from readme (@wlaurance)
+- [#64](https://github.com/plaidchat/plaidchat/pull/64) Added argument passing to plaidchat (@twolfson)
+- [#67](https://github.com/plaidchat/plaidchat/pull/67) Added CONTRIBUTING.md (@twolfson)
+- [#63](https://github.com/plaidchat/plaidchat/pull/63) Remove line from readme (@wlaurance)
 
 ### v1.4.2 (2015/05/28 15:20 +00:00)
-- [#52](https://github.com/slack-for-linux/slack-for-linux/pull/52) Locked down nw.js version (@twolfson)
+- [#52](https://github.com/plaidchat/plaidchat/pull/52) Locked down nw.js version (@twolfson)
 
 ### v1.4.1 (2015/05/05 22:44 +00:00)
-- [#45](https://github.com/slack-for-linux/slack-for-linux/pull/45) Add better install logging and fixed global nested npm install (@twolfson)
-- [#41](https://github.com/slack-for-linux/slack-for-linux/pull/41) Change the app name (@wlaurance)
+- [#45](https://github.com/plaidchat/plaidchat/pull/45) Add better install logging and fixed global nested npm install (@twolfson)
+- [#41](https://github.com/plaidchat/plaidchat/pull/41) Change the app name (@wlaurance)
 
 ### v1.4.0 (2015/04/29 01:44 +00:00)
-- [#30](https://github.com/slack-for-linux/slack-for-linux/pull/30) Added multi team support (@twolfson)
+- [#30](https://github.com/plaidchat/plaidchat/pull/30) Added multi team support (@twolfson)
 
 ### v1.2.2 (2015/04/29 00:50 +00:00)
-- [#29](https://github.com/slack-for-linux/slack-for-linux/pull/29) Added requirement for node>=0.10 (@twolfson)
-- [#33](https://github.com/slack-for-linux/slack-for-linux/pull/33) Added plugin flag to enable Flash. Fixes #32 (@twolfson)
-- [#26](https://github.com/slack-for-linux/slack-for-linux/pull/26) Fix download interaction. Fixes #25 (@twolfson)
-- [#24](https://github.com/slack-for-linux/slack-for-linux/pull/24) Added favicon notifications (@twolfson)
-- [#23](https://github.com/slack-for-linux/slack-for-linux/pull/23) Relocated closure variables into function (@twolfson)
+- [#29](https://github.com/plaidchat/plaidchat/pull/29) Added requirement for node>=0.10 (@twolfson)
+- [#33](https://github.com/plaidchat/plaidchat/pull/33) Added plugin flag to enable Flash. Fixes #32 (@twolfson)
+- [#26](https://github.com/plaidchat/plaidchat/pull/26) Fix download interaction. Fixes #25 (@twolfson)
+- [#24](https://github.com/plaidchat/plaidchat/pull/24) Added favicon notifications (@twolfson)
+- [#23](https://github.com/plaidchat/plaidchat/pull/23) Relocated closure variables into function (@twolfson)
 
 ### v1.2.1 (2015/03/09 17:45 +00:00)
-- [#19](https://github.com/slack-for-linux/slack-for-linux/pull/19) Fixed Slack's redirect URL (@twolfson)
+- [#19](https://github.com/plaidchat/plaidchat/pull/19) Fixed Slack's redirect URL (@twolfson)
 
 ### v1.2.0 (2015/01/06 17:13 +00:00)
-- [#11](https://github.com/slack-for-linux/slack-for-linux/pull/11) Sign back in to last team on relaunch (@canuc)
-- [#14](https://github.com/slack-for-linux/slack-for-linux/pull/14) Added jscs for style checking (@twolfson)
-- [#10](https://github.com/slack-for-linux/slack-for-linux/pull/10) Moved to grunt linters and added `.editorconfig` linting (@twolfson)
-- [#8](https://github.com/slack-for-linux/slack-for-linux/pull/8) Fixed up various one-off discrepencies (e.g. whitespace, shebang) (@twolfson)
+- [#11](https://github.com/plaidchat/plaidchat/pull/11) Sign back in to last team on relaunch (@canuc)
+- [#14](https://github.com/plaidchat/plaidchat/pull/14) Added jscs for style checking (@twolfson)
+- [#10](https://github.com/plaidchat/plaidchat/pull/10) Moved to grunt linters and added `.editorconfig` linting (@twolfson)
+- [#8](https://github.com/plaidchat/plaidchat/pull/8) Fixed up various one-off discrepencies (e.g. whitespace, shebang) (@twolfson)
 
 ### v0.1.0 (2014/12/16 14:10 +00:00)
-- [#3](https://github.com/slack-for-linux/slack-for-linux/pull/3) Fix for external urls launching within new webview window (@canuc)
-- [#2](https://github.com/slack-for-linux/slack-for-linux/pull/2) Fix for the iframe being small on launch (@canuc)
+- [#3](https://github.com/plaidchat/plaidchat/pull/3) Fix for external urls launching within new webview window (@canuc)
+- [#2](https://github.com/plaidchat/plaidchat/pull/2) Fix for the iframe being small on launch (@canuc)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 # Issues
 If you are opening an issue, please search for matching existing issues before creating a new one.
 
-https://github.com/slack-for-linux/slack-for-linux/issues
+https://github.com/plaidchat/plaidchat/issues
 
 If no issues are found, please include an explanatory subject and description that gives us context into:
 
 - If this is a bug
-	- Problem being seen (e.g. after loading `slack-for-linux`, I see a white screen)
-	- Expected behavior (e.g. after loading `slack-for-linux`, I should see Slack's normal interface)
+	- Problem being seen (e.g. after loading `plaidchat`, I see a white screen)
+	- Expected behavior (e.g. after loading `plaidchat`, I should see Slack's normal interface)
 	- Information about OS (e.g. `node --version`, `npm --version`, Ubuntu 14.04)
 - If this is an enhancement/discussion
 	- Provide details about behavior or context (e.g. adding linting to repo)
@@ -27,6 +27,6 @@ Interested in contributing? Great, we are always looking for more great people.
 
 Get started by finding an issue with the "help wanted" label and submitting a pull request.
 
-https://github.com/slack-for-linux/slack-for-linux/issues?q=label%3A%22help+wanted%22
+https://github.com/plaidchat/plaidchat/issues?q=label%3A%22help+wanted%22
 
 After your pull request is submitted, we might ask you to join as a contributor.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-slack-for-linux [![Build Status](https://travis-ci.org/slack-for-linux/slack-for-linux.svg?branch=master)](https://travis-ci.org/slack-for-linux/slack-for-linux)
+plaidchat [![Build Status](https://travis-ci.org/plaidchat/plaidchat.svg?branch=master)](https://travis-ci.org/plaidchat/plaidchat)
 =============
 
 Slack client for Linux. Uses [nw.js][].
@@ -18,13 +18,13 @@ Installing
 
 1) [Install Node.js](http://nodejs.org/download/). If Node.js is already installed, please continue.
 
-2) Install `slack-for-linux` via `npm`
+2) Install `plaidchat` via `npm`
 
 ```bash
-npm install slack-for-linux -g
+npm install plaidchat -g
 ```
 
-3) Run `slack-for-linux`
+3) Run `plaidchat`
 
 If you have setup correctly, the above command will install the package
 somewhere in your path.
@@ -32,7 +32,7 @@ somewhere in your path.
 Then you can run your client from your terminal of choice.
 
 ```bash
-slack-for-linux
+plaidchat
 ```
 
 Running and Developing
@@ -41,7 +41,7 @@ Running and Developing
 #### Clone the repo
 
 ```bash
-git clone git@github.com:slack-for-linux/slack-for-linux.git && cd slack-for-linux
+git clone git@github.com:plaidchat/plaidchat.git && cd plaidchat
 ```
 
 #### Install dependencies
@@ -65,7 +65,7 @@ machines. If you run into
 ./resources/node-webkit/Linux64/nw: error while loading shared libraries: libudev.so.0: cannot open shared object file: No such file or directory
 ```
 
-Give [Issue #1](https://github.com/slack-for-linux/slack-for-linux/issues/1) a look.
+Give [Issue #1](https://github.com/plaidchat/plaidchat/issues/1) a look.
 
 Contributing
 ============
@@ -73,11 +73,11 @@ Interested in contributing? Great, we are always looking for more great people.
 
 Get started by finding an issue with the "help wanted" label and submitting a pull request.
 
-https://github.com/slack-for-linux/slack-for-linux/issues?q=label%3A%22help+wanted%22
+https://github.com/plaidchat/plaidchat/issues?q=label%3A%22help+wanted%22
 
 License
 =======
-`slack-for-linux` is licensed under the [MIT license][].
+`plaidchat` is licensed under the [MIT license][].
 
 Upon installation, we may copy `libffmpegsumo.so` from `/opt/google/chrome` (from [ffmpeg][]) into our repository. We are required to mention that this file is licensed under the [GPL license][ffmpeg-license].
 

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -15,14 +15,14 @@
 	var LOCAL_STORAGE_KEY_CURRENT_DOMAIN = 'currentDomain';
 	var SLACK_DOMAIN = 'slack.com';
 	var SLACK_LOGIN_URL = 'https://slack.com/signin';
-	var webslack = {};
+	var plaidchat = {};
 
 	var win = gui.Window.get();
 	var validSlackSubdomain = /(.+)\.slack.com/i;
 	var slackDownloadHostname = 'files.slack.com';
 
 	// Interpet our CLI arguments
-	// DEV: We need to coerce `nw.js'` arguments as `commander` expects normal (`['node', 'slack-for-linux', '--help']`)
+	// DEV: We need to coerce `nw.js'` arguments as `commander` expects normal (`['node', 'plaidchat', '--help']`)
 	//   but `nw.js` only provides arguments themselves (e.g. `--help`)
 	var argv = ['nw', pkg.name].concat(gui.App.argv);
 	program
@@ -94,7 +94,7 @@
 		element: trayIconImg,
 		dataUrl: function (dataUrl) {
 			// Generate a location to save the image
-			var filepath = process.env.HOME + '/.slack-for-linux-tray.png';
+			var filepath = process.env.HOME + '/.plaidchat-tray.png';
 
 			// Convert the image to a stream
 			getUri(dataUrl, function handleData (err, dataStream) {
@@ -126,7 +126,7 @@
 	}
 
 	// On the initial page load
-	webslack.load = function () {
+	plaidchat.load = function () {
 		function newLocationToProcess(locationToProcess) {
 			var locationHostname = url.parse(locationToProcess).hostname;
 
@@ -170,7 +170,7 @@
 		// When the window loads
 		activeWindow.on('teams-loaded', function handleLoad () {
 			// Gather team info
-			// team = {id:, name: "slack-for-linux test", email_domain: mailinator.com, domain: account name,
+			// team = {id:, name: "plaidchat test", email_domain: mailinator.com, domain: account name,
 			//   msg_edit_window_mins, prefs: {default_channels, ...},
 			//   icon: {image_34: http://url/34.png, image_{44,68,88,102,132}, image_default: true},
 			//   over_storage_limit, plan, url: wss://ms144.slack-msgs.com, activity}
@@ -299,5 +299,5 @@
 		});
 	};
 
-	window.webslack = webslack;
+	window.plaidchat = plaidchat;
 })();

--- a/app/js/slack-window.js
+++ b/app/js/slack-window.js
@@ -42,7 +42,7 @@
 			// DEV: tinyspeck is Slack's company name, this is likely an in-house framework
 			var win = that.getWindow();
 			var TS = that.getTS();
-			if (TS && !win._slackForLinuxBoundListeners) {
+			if (TS && !win._plaidchatBoundListeners) {
 				// http://viewsource.in/https://slack.global.ssl.fastly.net/31971/js/rollup-client_1420067921.js#L6413-6419
 				// DEV: This is the same list that is used for growl notifications (`TS.ui.growls`)
 				var emitNotificationUpdate = function () {
@@ -64,7 +64,7 @@
 				if (TS.client) {
 					sig = TS.client.login_sig; if (sig) { sig.add(emitNotificationUpdate); }
 				}
-				win._slackForLinuxBoundListeners = true;
+				win._plaidchatBoundListeners = true;
 			}
 		});
 	}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>slack-for-linux</title>
+  <title>plaidchat</title>
   <link rel="stylesheet" href="../css/main.css" />
   <!-- DEV: favico.js is required to be loaded via `script` due to window properties like navigator not existing -->
   <script src="../../node_modules/favico.js/favico.js"></script>
@@ -9,7 +9,7 @@
 </head>
 <body>
   <script>
-    window.webslack.load();
+    window.plaidchat.load();
   </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "slack-for-linux",
+  "name": "plaidchat",
   "version": "1.6.3",
-  "description": "Slack client for linux",
+  "description": "A Linux client for Slack",
   "keywords": [
     "slack",
     "linux",
     "node-webkit"
   ],
-  "homepage": "https://github.com/slack-for-linux/slack-for-linux",
-  "bugs": "https://github.com/slack-for-linux/slack-for-linux/issues",
+  "homepage": "https://github.com/plaidchat/plaidchat",
+  "bugs": "https://github.com/plaidchat/plaidchat/issues",
   "author": {
     "name": "Will Laurance",
     "email": "",
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/slack-for-linux/slack-for-linux"
+    "url": "git://github.com/plaidchat/plaidchat"
   },
   "main": "app/views/index.html",
   "dependencies": {
@@ -38,7 +38,7 @@
     "postinstall": "./postinstall.sh"
   },
   "bin": {
-    "slack-for-linux": "./run.js"
+    "plaidchat": "./run.js"
   },
   "devDependencies": {
     "github-changes": "^1.0.0",
@@ -50,7 +50,7 @@
   },
   "single-instance": true,
   "window": {
-    "title": "Slack for Linux",
+    "title": "plaidchat",
     "icon": "./images/app-256.png",
     "width": 650,
     "height": 650,

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -7,5 +7,5 @@ if test -f /opt/google/chrome/libffmpegsumo.so; then
 	cp /opt/google/chrome/libffmpegsumo.so node_modules/nw/nwjs/libffmpegsumo.so
 else
 	echo "Couldn't locate libffmpegsumo.so during installation. Audio notifications will be disabled" 1>&2
-	echo "To repair this, please install Google Chrome and reinstall \`slack-for-linux\`" 1>&2
+	echo "To repair this, please install Google Chrome and reinstall \`plaidchat\`" 1>&2
 fi

--- a/release.sh
+++ b/release.sh
@@ -26,8 +26,8 @@ npm version "$version"
 semver="$(node --eval "console.log('v' + require('./package.json').version);")"
 
 # Generate a new CHANGELOG
-./node_modules/.bin/github-changes --title "slack-for-linux changelog" \
-	--owner slack-for-linux --repository slack-for-linux \
+./node_modules/.bin/github-changes --title "plaidchat changelog" \
+	--owner plaidchat --repository plaidchat \
 	--only-pulls --use-commit-body -n "$semver"
 
 # DEV: Add trailing newline for linter


### PR DESCRIPTION
As agreed upon in #79, we have renamed our organization/repo to `plaidchat`. This PR completes the transition by updating all references from `slack-for-linux` to `plaidchat`. In this PR:

- Updated documentation
- Updated `package.json`
- Updated `js` (we had a `slackForLinux` in the code as well as `webslack`)

/cc @wlaurance 