### PR TITLE
Added FAQ section for crashing on direct message

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ More information can be read in the Flux documentation:
 
 Issues
 ======
+libudev.so
+----------
 [JBKahn](https://github.com/JBKahn) Pointed out that libudev.so differs on different
 machines. If you run into
 
@@ -96,6 +98,19 @@ machines. If you run into
 ```
 
 Give [Issue #1](https://github.com/plaidchat/plaidchat/issues/1) a look.
+
+Crashing when receiving direct message
+--------------------------------------
+We have had multiple reports of `plaidchat` crashing when a direct message is received.
+
+This typically is caused by installing while an older version of Google Chrome is on your machine (we use its `libffmpegsumo.so` for audio bindings).
+
+To fix the issue, perform the following steps:
+
+1. Update your version of Google Chrome to its latest version
+	- For example, if your Google Chrome was installed via `apt`/`dpkg`, then run `apt-get install google-chrome-stable`
+2. Reinstall `plaidchat` to pick up the latest version of `libffmpegsumo.so`
+	- `npm uninstall -g plaidchat && npm install -g plaidchat`
 
 Contributing
 ============


### PR DESCRIPTION
We have received our second report for crashes when `libffmpegsumo.so` is out of date. In order to decrease the amount of issues, we are adding another FAQ to the README. In this PR:

- Added "Crashing when receiving direct message" section to FAQs in README
- Fixes #86 

/cc @wlaurance 