### PR TITLE
Completed --minimize-to-tray support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,4 +13,6 @@ indent_style = space
 indent_size = 2
 
 [*.md]
+indent_style = space
+indent_size = 4
 trim_trailing_whitespace = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,11 @@ https://github.com/plaidchat/plaidchat/issues
 If no issues are found, please include an explanatory subject and description that gives us context into:
 
 - If this is a bug
-	- Problem being seen (e.g. after loading `plaidchat`, I see a white screen)
-	- Expected behavior (e.g. after loading `plaidchat`, I should see Slack's normal interface)
-	- Information about OS (e.g. `node --version`, `npm --version`, Ubuntu 14.04)
+    - Problem being seen (e.g. after loading `plaidchat`, I see a white screen)
+    - Expected behavior (e.g. after loading `plaidchat`, I should see Slack's normal interface)
+    - Information about OS (e.g. `node --version`, `npm --version`, Ubuntu 14.04)
 - If this is an enhancement/discussion
-	- Provide details about behavior or context (e.g. adding linting to repo)
+    - Provide details about behavior or context (e.g. adding linting to repo)
 
 # Pull requests
 When opening a pull request:
@@ -18,9 +18,9 @@ When opening a pull request:
 - If there was an original issue, then please provide a link to
 - Otherwise, please provide description that follows the guidelines from [Issues](#issues)
 - Please focus on 1 feature/patch at a time in a pull request
-	- If multiple features/patches, consider creating multiple pull requests for each one
+    - If multiple features/patches, consider creating multiple pull requests for each one
 - Please collapse/squash new commits in a pull request into 1 commit
-	- If this depends on another pull request, do not collapse/squash that pull request's commit into this one's
+    - If this depends on another pull request, do not collapse/squash that pull request's commit into this one's
 
 # Contributing
 Interested in contributing? Great, we are always looking for more great people.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,11 @@ module.exports = function (grunt) {
 			}
 		},
 		lintspaces: {
-			src: ['*', 'app/**/*', '!**/*.png'],
+			src: [
+				'*', 'app/**/*',
+				'!**/*.png', // Exclude images to prevent odd errors
+				'!README.md' // Exclude README due to CLI indentation
+			],
 			options: {
 				editorconfig: '.editorconfig'
 			}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ plaidchat
 
 `plaidchat` is not created by, affiliated with, or supported by Slack Technologies, Inc.
 
+CLI options
+===========
+We provide various CLI options via `plaidchat --help`
+
+```bash
+$ plaidchat --help
+
+  Usage: plaidchat [options]
+
+  Options:
+
+    -h, --help          output usage information
+    -V, --version       output the version number
+    --minimize-to-tray  When the tray icon is clicked, hide the window rather than minimize
+
+```
+
 Running and Developing
 ======================
 
@@ -63,12 +80,12 @@ Application structure
 Our application is built on top of [React][] and [Flux][]. The folders for our application are:
 
 - app/ - Container for our application
-	- css/ - CSS for our application
-	- components/ - Container for different React components
-	- dispatchers/ - Container for Flux dispatchers
-	- js/ - JS that handle `nw.js` setup and initial loading of React
-	- stores/ - Container for Flux stores
-	- views/ - HTML pages loaded by `nw.js`
+    - css/ - CSS for our application
+    - components/ - Container for different React components
+    - dispatchers/ - Container for Flux dispatchers
+    - js/ - JS that handle `nw.js` setup and initial loading of React
+    - stores/ - Container for Flux stores
+    - views/ - HTML pages loaded by `nw.js`
 
 [React]: https://github.com/facebook/react
 [Flux]: http://github.com/facebook/flux
@@ -76,11 +93,11 @@ Our application is built on top of [React][] and [Flux][]. The folders for our a
 With the [Flux][] infrastructure, all our data flows one-way; from components to dispatchers to stores to components (and repeat).
 
 - Components manage the DOM and rendering other components
-	- From the MVC perspective, it's a hybrid of controllers/views
+    - From the MVC perspective, it's a hybrid of controllers/views
 - Dispatchers manage passing through events from components to stores
-	- These are more/less global single-channel mediators
+    - These are more/less global single-channel mediators
 - Stores manage internal application data and emit events on change
-	- These are a hybrid of models/controllers as they both save state as well as manage its updates
+    - These are a hybrid of models/controllers as they both save state as well as manage its updates
 
 More information can be read in the Flux documentation:
 
@@ -108,9 +125,9 @@ This typically is caused by installing while an older version of Google Chrome i
 To fix the issue, perform the following steps:
 
 1. Update your version of Google Chrome to its latest version
-	- For example, if your Google Chrome was installed via `apt`/`dpkg`, then run `apt-get install google-chrome-stable`
+    - For example, if your Google Chrome was installed via `apt`/`dpkg`, then run `apt-get install google-chrome-stable`
 2. Reinstall `plaidchat` to pick up the latest version of `libffmpegsumo.so`
-	- `npm uninstall -g plaidchat && npm install -g plaidchat`
+    - `npm uninstall -g plaidchat && npm install -g plaidchat`
 
 Contributing
 ============

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -20,7 +20,7 @@
 	var argv = ['nw', pkg.name].concat(gui.App.argv);
 	program
 		.version(pkg.version)
-		.option('--minimize-to-tray')
+		.option('--minimize-to-tray', 'When the tray icon is clicked, hide the window rather than minimize')
 		.parse(argv);
 
 	win.on('new-win-policy', function (frame, urlStr, policy) {
@@ -44,44 +44,16 @@
 		console.debug('Allowing browser to handle: ' + JSON.stringify(openRequest));
 	});
 
+	// Track minimization/hidden state
+	// DEV: isHidden only changes programmatically; there are no events for it
 	var isHidden = false;
-
-	win.on('hide', function () {
-		isHidden = true;
+	var isMinimized = false;
+	win.on('minimize', function saveMinimization () {
+		isMinimized = true;
 	});
-	win.on('minimize', function () {
-		isHidden = true;
+	win.on('restore', function saveRestoration () {
+		isMinimized = false;
 	});
-	win.on('show', function () {
-		isHidden = false;
-	});
-	win.on('restore', function () {
-		isHidden = false;
-	});
-
-	var windowShowCommand = program.minimizeToTray ? 'show' : 'restore';
-	var windowHideCommand = program.minimizeToTray ? 'hide' : 'minimize';
-
-	function showWindow() {
-		win[windowShowCommand]();
-		isHidden = false;
-	};
-	function hideWindow() {
-		win[windowHideCommand]();
-		isHidden = true;
-	};
-
-  gui.App.on('open', function (cmdline) {
-		showWindow();
-  });
-
-	function toggleVisibility() {
-		if (isHidden) {
-			showWindow();
-		} else {
-			hideWindow();
-		}
-	}
 
 	// Define a global set of controls for `plaidchat`
 	var plaidchat = {
@@ -122,14 +94,52 @@
 				win.showDevTools();
 			}
 		},
-		// Method to toggle window visibility
-		toggleVisibility: function () {
+
+		// Methods to toggle window visibility
+		_showMinimize: function () {
+			win.restore();
+		},
+		_toggleMinimize: function () {
 			if (isMinimized) {
-				win.restore();
+				plaidchat._showMinimize();
 			} else {
-				win.minimize();
+				win.minimize(); // plaidchat._hideMinimize
+			}
+		},
+		_showHidden: function () {
+			win.show();
+			isHidden = false;
+		},
+		_toggleHidden: function () {
+			if (isMinimized || isHidden) {
+				plaidchat._showHidden();
+			} else {
+				win.hide(); // plaidchat._hideHidden
+				isHidden = true;
+			}
+		},
+		showWindow: function () {
+			if (program.minimizeToTray) {
+				plaidchat._showHidden();
+			} else {
+				plaidchat._showMinimize();
+			}
+		},
+		toggleVisibility: function () {
+			if (program.minimizeToTray) {
+				plaidchat._toggleHidden();
+			} else {
+				plaidchat._toggleMinimize();
 			}
 		}
 	};
+
+	// When `plaidchat` is run and we have an existing window, show the window
+	// DEV: This only works when we have `single-instance: true` set
+	gui.App.on('open', function handleOpen (cmdline) {
+		plaidchat.showWindow();
+	});
+
+	// Expose plaidchat to other modules
 	window.plaidchat = plaidchat;
 })();


### PR DESCRIPTION
This PR rebases #68 (to avoid an extra merge commit) and finishes up discrepancies with the changes in #85. When this PR is landed, both #65 and this PR should appear in the CHANGELOG.

In this PR:

- Fixed up #68 
- Added in CLI options documentation to README
- Relocated window controls into `plaidchat` for reuse in other files 
- Removed `hide`/`restore` event listeners as those don't actually exist =/
    - https://github.com/nwjs/nw.js/wiki/Window#events

/cc @wlaurance