### PR TITLE
Added application menu

### DIFF
--- a/app/components/app-menu.js
+++ b/app/components/app-menu.js
@@ -1,0 +1,70 @@
+(function () {
+	'use strict';
+	// Load in our dependencies
+	var gui = require('nw.gui');
+	var pkg = require('../../package.json');
+
+	// Define an AppMenu factory on window
+	window.AppMenu = {
+		// When requested to bind an app menu to a window
+		bindTo: function (win) {
+			// Generate our menu
+			// Menus are inspired by
+			// https://github.com/atom/electron-starter/blob/96f6117b4c1f33c0881d504d655467fc049db433/menus/linux.cson
+			var menu = new gui.Menu({
+				type: 'menubar'
+			});
+
+			// Add File menu dropdown
+			var fileSubmenu = new gui.Menu();
+			fileSubmenu.append(new gui.MenuItem({
+				label: 'Quit - Ctrl+Q',
+				click: window.plaidchat.exit,
+				key: 'q', // ctrl+q to quit
+				modifiers: 'ctrl'
+			}));
+			menu.append(new gui.MenuItem({
+				label: 'File',
+				submenu: fileSubmenu
+			}));
+
+			// Add View menu dropdown
+			var viewSubmenu = new gui.Menu();
+			viewSubmenu.append(new gui.MenuItem({
+				label: 'Reload - Ctrl+R',
+				click: window.plaidchat.reload,
+				key: 'r', // ctrl+r to reload
+				modifiers: 'ctrl'
+			}));
+			var developerSubsubmenu = new gui.Menu();
+			developerSubsubmenu.append(new gui.MenuItem({
+				label: 'Toggle Developer Tools - Ctrl+Shift+I',
+				click: window.plaidchat.toggleDevTools,
+				key: 'i', // ctrl++shift+i to open dev tools
+				modifiers: 'ctrl-shift'
+			}));
+			viewSubmenu.append(new gui.MenuItem({
+				label: 'Developer',
+				submenu: developerSubsubmenu
+			}));
+			menu.append(new gui.MenuItem({
+				label: 'View',
+				submenu: viewSubmenu
+			}));
+
+			// Add Help menu dropdown
+			var helpSubmenu = new gui.Menu();
+			helpSubmenu.append(new gui.MenuItem({
+				label: 'About plaidchat',
+				click: window.plaidchat.openAboutWindow
+			}));
+			menu.append(new gui.MenuItem({
+				label: 'Help',
+				submenu: helpSubmenu
+			}));
+
+			// Bind the menu to the window
+			win.menu = menu;
+		}
+	};
+}());

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -4,6 +4,7 @@
 	var gui = require('nw.gui');
 	var url = require('url');
 	var program = require('commander');
+	var AppMenu = window.AppMenu;
 	var React = window.React;
 	// DEV: Relative paths are resolved from `views/index.html`
 	var SlackApplication = require('../components/slack-application');
@@ -58,8 +59,15 @@
 			console.debug('Exiting plaidchat...');
 			process.exit();
 		},
+		// Method to reload our window
+		reload: function () {
+			win.reload();
+		},
 		// Method to start our application
 		load: function () {
+			// Bind our app menu to the window
+			AppMenu.bindTo(win);
+
 			// Setup initial team
 			SlackApplication.loadInitialTeams();
 
@@ -67,6 +75,21 @@
 			var slackApp = React.createElement(SlackApplication, null);
 			plaidchat.app = React.render(slackApp, document.body);
 			console.debug('Starting application...');
+		},
+		openAboutWindow: function () {
+			gui.Window.open('about.html', {
+				height: 200,
+				width: 400,
+				toolbar: false
+			});
+		},
+		// Method to open our dev tools (hooray development :tada:)
+		toggleDevTools: function () {
+			if (win.isDevToolsOpen()) {
+				win.closeDevTools();
+			} else {
+				win.showDevTools();
+			}
 		},
 		// Method to toggle window visibility
 		toggleVisibility: function () {

--- a/app/views/about.html
+++ b/app/views/about.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>plaidchat - about</title>
+  <style>
+    /* https://github.com/corysimmons/typographic/blob/2.9.3/scss/typographic.scss#L34 */
+    body {
+      text-align: center;
+      font-family: 'Helvetica Neue', 'Helvetica', 'Arial', 'sans-serif';
+    }
+  </style>
+</head>
+<body>
+  <script>
+    window.pkg = require('../../package.json');
+  </script>
+  <div>
+    <h1>plaidchat</h1>
+    <p>
+      <!-- DEV: Rather than importing a template language or generating all copy from HTML, we are using a hack to write out the document as it's parsed via JavaScript -->
+      Version: <script>document.write(pkg.version);</script>
+      <br/>
+      nw.js version: <script>document.write(process.versions['node-webkit']);</script>
+      <br/>
+      Chromium version: <script>document.write(process.versions.chromium);</script>
+    </p>
+  </div>
+</body>
+</html>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -7,7 +7,8 @@
   <script src="../../node_modules/favico.js/favico.js"></script>
   <!-- We must use a special flavor of React with support for `nw.js` HTML attributes -->
   <script src="../../dist/js/react.js"></script>
-  <!-- DEV: AppTray needs to be loaded with access to `nw.gui` -->
+  <!-- DEV: AppMenu and AppTray need to be loaded with access to `nw.gui` -->
+  <script src="../components/app-menu.js" ></script>
   <script src="../components/app-tray.js" ></script>
   <script src="../js/index.js" ></script>
 </head>


### PR DESCRIPTION
When doing development, I typically turn `toolbar` from `false` to `true` in the `package.json` in order to get access to Dev Tools. However, I think this should be more easily accessible to others. As a result, I am adding in an application menu which exposes this.

In this PR:

- Added application menu (with quit, reload, toggle dev tools, and about page)
- Added various `plaidchat` functions that bind to each menu items

**Notes:**

An added bonus of this menu is that there's a page with installation information to help us debug more easily.

/cc @wlaurance 