### PR TITLE
Added notification badges to sidebar

### DIFF
--- a/app/components/app-menu.js
+++ b/app/components/app-menu.js
@@ -1,0 +1,70 @@
+(function () {
+	'use strict';
+	// Load in our dependencies
+	var gui = require('nw.gui');
+	var pkg = require('../../package.json');
+
+	// Define an AppMenu factory on window
+	window.AppMenu = {
+		// When requested to bind an app menu to a window
+		bindTo: function (win) {
+			// Generate our menu
+			// Menus are inspired by
+			// https://github.com/atom/electron-starter/blob/96f6117b4c1f33c0881d504d655467fc049db433/menus/linux.cson
+			var menu = new gui.Menu({
+				type: 'menubar'
+			});
+
+			// Add File menu dropdown
+			var fileSubmenu = new gui.Menu();
+			fileSubmenu.append(new gui.MenuItem({
+				label: 'Quit - Ctrl+Q',
+				click: window.plaidchat.exit,
+				key: 'q', // ctrl+q to quit
+				modifiers: 'ctrl'
+			}));
+			menu.append(new gui.MenuItem({
+				label: 'File',
+				submenu: fileSubmenu
+			}));
+
+			// Add View menu dropdown
+			var viewSubmenu = new gui.Menu();
+			viewSubmenu.append(new gui.MenuItem({
+				label: 'Reload - Ctrl+R',
+				click: window.plaidchat.reload,
+				key: 'r', // ctrl+r to reload
+				modifiers: 'ctrl'
+			}));
+			var developerSubsubmenu = new gui.Menu();
+			developerSubsubmenu.append(new gui.MenuItem({
+				label: 'Toggle Developer Tools - Ctrl+Shift+I',
+				click: window.plaidchat.toggleDevTools,
+				key: 'i', // ctrl++shift+i to open dev tools
+				modifiers: 'ctrl-shift'
+			}));
+			viewSubmenu.append(new gui.MenuItem({
+				label: 'Developer',
+				submenu: developerSubsubmenu
+			}));
+			menu.append(new gui.MenuItem({
+				label: 'View',
+				submenu: viewSubmenu
+			}));
+
+			// Add Help menu dropdown
+			var helpSubmenu = new gui.Menu();
+			helpSubmenu.append(new gui.MenuItem({
+				label: 'About plaidchat',
+				click: window.plaidchat.openAboutWindow
+			}));
+			menu.append(new gui.MenuItem({
+				label: 'Help',
+				submenu: helpSubmenu
+			}));
+
+			// Bind the menu to the window
+			win.menu = menu;
+		}
+	};
+}());

--- a/app/components/slack-application.js
+++ b/app/components/slack-application.js
@@ -6,6 +6,7 @@
 	var React = window.React;
 	var AppDispatcher = require('../dispatchers/app');
 	var SlackWindow = require('./slack-window');
+	var NotificationStore = require('../stores/notification');
 	var TeamStore = require('../stores/team');
 	var TeamSidebar = require('./team-sidebar');
 
@@ -18,6 +19,7 @@
 	function getStateFromStores() {
 		return {
 			activeTeamId: TeamStore.getActiveTeamId(),
+			notificationsByTeamId: NotificationStore.getNotificationsByTeamId(),
 			teams: TeamStore.getTeams(),
 			teamsById: TeamStore.getTeamsById(),
 			teamIndicies: TeamStore.getTeamIndicies(),
@@ -33,10 +35,12 @@
 		// When our application loads/unloads start/stop listening for change events in our teams
 		//   and load/unload non-react components (e.g. Tray)
 		componentDidMount: function () {
+			NotificationStore.addChangeListener(this._onChange);
 			TeamStore.addChangeListener(this._onChange);
 			AppTray.mount();
 		},
 		componentWillUnmount: function () {
+			NotificationStore.removeChangeListener(this._onChange);
 			TeamStore.removeChangeListener(this._onChange);
 			AppTray.unmount();
 		},
@@ -70,7 +74,7 @@
 			}, [
 				React.createElement(TeamSidebar, _.defaults({
 					key: 'sidebar'
-				}, _.pick(this.state, 'activeTeamId', 'teams', 'teamIcons', 'teamIndicies'))),
+				}, _.pick(this.state, 'activeTeamId', 'notificationsByTeamId', 'teams', 'teamIcons', 'teamIndicies'))),
 				React.DOM.div({
 					className: 'slack-window-container',
 					key: 'window-container'

--- a/app/components/team-sidebar.js
+++ b/app/components/team-sidebar.js
@@ -39,22 +39,33 @@
 				className: props.teams.length >= 2 ? 'team-sidebar' : 'team-sidebar hidden'
 			}, props.teams.map(function createTeamRow (team) {
 				var teamIcon = props.teamIcons[team.team_id];
-				return React.DOM.p({
+				var notificationCount = props.notificationsByTeamId[team.team_id] || 0;
+				return React.DOM.div({
 					className: team.team_id === props.activeTeamId ?
-							'team-sidebar__item team-sidebar__item--active' :
-							'team-sidebar__item',
+							'team-sidebar__row team-sidebar__row--active' :
+							'team-sidebar__row',
 					key: props.teamIndicies[team.team_id]
 				}, [
-					React.DOM.a({
-						'data-team-id': team.team_id,
-						href: '#',
-						key: 'link',
-						onClick: _onClick
+					React.DOM.div({
+						className: 'badge-container team-sidebar__badge-container',
+						key: 'badge-container'
 					}, [
-						React.DOM.img({
-							key: 'img',
-							src: teamIcon ? teamIcon.image_44 : null
-						})
+						React.DOM.a({
+							'data-team-id': team.team_id,
+							href: '#',
+							key: 'link',
+							onClick: _onClick
+						}, [
+							React.DOM.div({
+								key: 'badge',
+								className: notificationCount ? 'badge' : 'badge hidden'
+							}, notificationCount.toString()),
+							React.DOM.img({
+								className: 'icon--small',
+								key: 'img',
+								src: teamIcon ? teamIcon.image_44 : null
+							})
+						])
 					])
 				]);
 			}));

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -1,3 +1,4 @@
+/* Base styles */
 html, body {
 	width: 100%;
 	height: 100%;
@@ -7,7 +8,48 @@ html, body {
 	overflow: hidden;
 }
 
-/* Application specific classes */
+body {
+	/* http://viewsource.in/https://slack.global.ssl.fastly.net/8607/style/rollup-client_secondary.css#L251 */
+	font-family: 'Emoji Passthrough', Lato, appleLogo, sans-serif;
+}
+
+a {
+	color: inherit;
+}
+
+/* Generic components/classes */
+.badge-container {
+	position: relative;
+}
+
+.badge {
+	position: absolute;
+	/* Position in upper right at midpoint of badge */
+	right: -9px;
+	top: -9px;
+	/* Paint our badge red */
+	/* http://viewsource.in/https://slack.global.ssl.fastly.net/c239/style/rollup-client_secondary.css#L2536 */
+	background: #eb4d5c;
+	/* Make a square badge */
+	width: 18px;
+	height: 18px;
+	/* Make our badge circular */
+	border-radius: 9px;
+	/* Adjust find sizings to line up */
+	font-size: 14px;
+	line-height: 18px; /* Same as width/height */
+}
+
+.icon--small {
+	/* http://viewsource.in/https://slack.global.ssl.fastly.net/c239/style/rollup-client_secondary.css#L1070 */
+	border-radius: 0.2rem;
+
+	/* Scale down to be same size as user icons */
+	height: 36px;
+	width: 36px;
+}
+
+/* Application specific components/classes */
 /* Application container */
 .slack-application {
 	display: flex;
@@ -25,24 +67,11 @@ html, body {
 	text-align: center;
 }
 
-.team-sidebar a {
-	color: inherit;
+.team-sidebar__row {
+	margin: 16px 0;
 }
 
-.team-sidebar__item {
-	list-style: none;
-}
-
-.team-sidebar__item img {
-	/* http://viewsource.in/https://slack.global.ssl.fastly.net/c239/style/rollup-client_secondary.css#L1070 */
-	border-radius: 0.2rem;
-
-	/* Scale down to be same size as user icons */
-	height: 36px;
-	width: auto;
-}
-
-.team-sidebar__item--active::before {
+.team-sidebar__row--active::before {
 	display: block;
 	position: absolute;
 	content: '\A0';
@@ -54,6 +83,12 @@ html, body {
 
 	/* Use same border radius as icon for good measure*/
 	border-radius: 0 0.2rem 0.2rem 0;
+}
+
+/* One-off to make badge-container same width as icon--small */
+.team-sidebar__badge-container {
+	width: 36px;
+	margin: 0 auto;
 }
 
 /* Window switcher */

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -4,6 +4,7 @@
 	var gui = require('nw.gui');
 	var url = require('url');
 	var program = require('commander');
+	var AppMenu = window.AppMenu;
 	var React = window.React;
 	// DEV: Relative paths are resolved from `views/index.html`
 	var SlackApplication = require('../components/slack-application');
@@ -58,8 +59,15 @@
 			console.debug('Exiting plaidchat...');
 			process.exit();
 		},
+		// Method to reload our window
+		reload: function () {
+			win.reload();
+		},
 		// Method to start our application
 		load: function () {
+			// Bind our app menu to the window
+			AppMenu.bindTo(win);
+
 			// Setup initial team
 			SlackApplication.loadInitialTeams();
 
@@ -67,6 +75,21 @@
 			var slackApp = React.createElement(SlackApplication, null);
 			plaidchat.app = React.render(slackApp, document.body);
 			console.debug('Starting application...');
+		},
+		openAboutWindow: function () {
+			gui.Window.open('about.html', {
+				height: 200,
+				width: 400,
+				toolbar: false
+			});
+		},
+		// Method to open our dev tools (hooray development :tada:)
+		toggleDevTools: function () {
+			if (win.isDevToolsOpen()) {
+				win.closeDevTools();
+			} else {
+				win.showDevTools();
+			}
 		},
 		// Method to toggle window visibility
 		toggleVisibility: function () {

--- a/app/stores/notification.js
+++ b/app/stores/notification.js
@@ -48,6 +48,9 @@
 			// ['xyz'].forEach(unsetTeamNotifications)
 			Object.keys(excessTeamNotifications).forEach(this.unsetTeamNotifications);
 		},
+		getNotificationsByTeamId: function () {
+			return _.clone(_state.notificationsByTeamId);
+		},
 		getNotificationTotal: function () {
 			var notificationCounts = _.values(_state.notificationsByTeamId);
 			return notificationCounts.reduce(function sumNotificationCounts (sum, notificationCount) {

--- a/app/views/about.html
+++ b/app/views/about.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>plaidchat - about</title>
+  <style>
+    /* https://github.com/corysimmons/typographic/blob/2.9.3/scss/typographic.scss#L34 */
+    body {
+      text-align: center;
+      font-family: 'Helvetica Neue', 'Helvetica', 'Arial', 'sans-serif';
+    }
+  </style>
+</head>
+<body>
+  <script>
+    window.pkg = require('../../package.json');
+  </script>
+  <div>
+    <h1>plaidchat</h1>
+    <p>
+      <!-- DEV: Rather than importing a template language or generating all copy from HTML, we are using a hack to write out the document as it's parsed via JavaScript -->
+      Version: <script>document.write(pkg.version);</script>
+      <br/>
+      nw.js version: <script>document.write(process.versions['node-webkit']);</script>
+      <br/>
+      Chromium version: <script>document.write(process.versions.chromium);</script>
+    </p>
+  </div>
+</body>
+</html>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -7,7 +7,8 @@
   <script src="../../node_modules/favico.js/favico.js"></script>
   <!-- We must use a special flavor of React with support for `nw.js` HTML attributes -->
   <script src="../../dist/js/react.js"></script>
-  <!-- DEV: AppTray needs to be loaded with access to `nw.gui` -->
+  <!-- DEV: AppMenu and AppTray need to be loaded with access to `nw.gui` -->
+  <script src="../components/app-menu.js" ></script>
   <script src="../components/app-tray.js" ></script>
   <script src="../js/index.js" ></script>
 </head>


### PR DESCRIPTION
**Depends on #91 due to using dev tools for development**

One of the most requested features is notification badges. Now that the React refactor is over, we can easily add them in. In this PR:

- Added in notification badges to sidebar
- Refactored CSS to make it more OOCSS-like

**Notes:**

It looks like the official Slack client has an unread state for teams (grey triangle on left of badges). However, our current implementation doesn't distinguish unread notifications from other ones. I will open up another issue to get the implementation right.

Here's a screenshot of the final result:

![selection_143](https://cloud.githubusercontent.com/assets/902488/8348723/f79c5a5c-1adb-11e5-88be-ede7952bb039.png)

/cc @wlaurance 