### PR TITLE
Added unread triangle and fixed notification count

### DIFF
--- a/app/components/app-tray.js
+++ b/app/components/app-tray.js
@@ -72,12 +72,55 @@
 		},
 		// When our notification count changes, update our badge with the total
 		_handleNotificationUpdate: function () {
-			var unreadTotal = NotificationStore.getNotificationTotal();
-			if (unreadTotal) {
-				this._favicon.badge(unreadTotal);
+			// If nothing has changed since the last update, do nothing
+			var notificationSummary = NotificationStore.getNotificationSummary();
+			if (this._state) {
+				var pastUnreadCount = this._state.unreadCount || 0;
+				var nextUnreadCount = notificationSummary.unreadCount || 0;
+				var pastUnreadHighlightCount = Math.min(this._state.unreadHighlightsCount || 0, 10);
+				var nextUnreadHighlightCount = Math.min(notificationSummary.unreadHighlightsCount || 0, 10);
+				var logInfo = {
+					pastUnreadCount: pastUnreadCount,
+					nextUnreadCount: nextUnreadCount,
+					pastUnreadHighlightCount: pastUnreadHighlightCount,
+					nextUnreadHighlightCount: nextUnreadHighlightCount
+				};
+				if (pastUnreadHighlightCount && pastUnreadHighlightCount === nextUnreadHighlightCount) {
+					console.debug('[AppTray] Highlight notifications are active and have not changed. Not updating tray icon.', logInfo);
+					return;
+				} else if (pastUnreadCount === nextUnreadCount) {
+					console.debug('[AppTray] Unread notifications have not changed. Not updating tray icon.', logInfo);
+					return;
+				} else {
+					console.debug('[AppTray] Notification counts have changed. Allowing tray icon update to occur.', logInfo);
+				}
+			}
+
+			// Update our badge
+			// https://github.com/ejci/favico.js/blob/0.3.7/favico.js#L30
+			console.debug('[AppTray] Updating tray icon with new notifications count', {
+				unreadCount: notificationSummary.unreadCount,
+				unreadHighlightsCount: notificationSummary.unreadHighlightsCount
+			});
+			if (notificationSummary.unreadHighlightsCount) {
+				// Cap off our notification count at 9+ (like Slack)
+				// http://viewsource.in/https://slack.global.ssl.fastly.net/31971/js/rollup-client_1420067921.js#L6496-6500
+				var unreadHighlightsCount = notificationSummary.unreadHighlightsCount;
+				if (notificationSummary.unreadHighlightsCount > 9) {
+					unreadHighlightsCount = '9+';
+				}
+				this._favicon.badge(unreadHighlightsCount, {bgColor: '#D00'});
+			} else if (notificationSummary.unreadCount) {
+				// Display a bullet for unreads (like Slack)
+				// http://viewsource.in/https://slack.global.ssl.fastly.net/31971/js/rollup-client_1420067921.js#L6496-6500
+				// https://en.wikipedia.org/wiki/Bullet_%28typography%29
+				this._favicon.badge('\u2022', {bgColor: '#666'});
 			} else {
 				this._favicon.reset();
 			}
+
+			// Save the new summary for comparison
+			this._state = notificationSummary;
 		},
 		// When requested to remove our tray
 		unmount: function () {

--- a/app/components/team-sidebar.js
+++ b/app/components/team-sidebar.js
@@ -39,11 +39,17 @@
 				className: props.teams.length >= 2 ? 'team-sidebar' : 'team-sidebar hidden'
 			}, props.teams.map(function createTeamRow (team) {
 				var teamIcon = props.teamIcons[team.team_id];
-				var notificationCount = props.notificationsByTeamId[team.team_id] || 0;
+				var notificationInfo = props.notificationsByTeamId[team.team_id];
+				var unreadHighlightsCount = notificationInfo ? notificationInfo.unreadHighlightsCount : 0;
+				if (unreadHighlightsCount > 9) {
+					unreadHighlightsCount = '9+';
+				}
 				return React.DOM.div({
 					className: team.team_id === props.activeTeamId ?
 							'team-sidebar__row team-sidebar__row--active' :
-							'team-sidebar__row',
+							(notificationInfo && notificationInfo.unreadCount) ?
+								'team-sidebar__row team-sidebar__row--unread' :
+								'team-sidebar__row',
 					key: props.teamIndicies[team.team_id]
 				}, [
 					React.DOM.div({
@@ -58,8 +64,8 @@
 						}, [
 							React.DOM.div({
 								key: 'badge',
-								className: notificationCount ? 'badge' : 'badge hidden'
-							}, notificationCount.toString()),
+								className: unreadHighlightsCount ? 'badge' : 'badge hidden'
+							}, unreadHighlightsCount.toString()),
 							React.DOM.img({
 								className: 'icon--small',
 								key: 'img',

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -69,6 +69,7 @@ a {
 
 .team-sidebar__row {
 	margin: 16px 0;
+	position: relative;
 }
 
 .team-sidebar__row--active::before {
@@ -81,8 +82,21 @@ a {
 	/* Same as icon */
 	height: 36px;
 
-	/* Use same border radius as icon for good measure*/
+	/* Use same border radius as icon for good measure */
 	border-radius: 0 0.2rem 0.2rem 0;
+}
+
+.team-sidebar__row--unread::before {
+	display: block;
+	position: absolute;
+	content: '\A0';
+	/* https://css-tricks.com/snippets/css/css-triangle/ */
+	width: 0;
+	height: 0;
+	border-top: 4px solid transparent;
+	border-bottom: 4px solid transparent;
+	border-left: 4px solid #A296A4;
+	top: 14px;
 }
 
 /* One-off to make badge-container same width as icon--small */

--- a/app/stores/notification.js
+++ b/app/stores/notification.js
@@ -51,14 +51,16 @@
 		getNotificationsByTeamId: function () {
 			return _.clone(_state.notificationsByTeamId);
 		},
-		getNotificationTotal: function () {
-			var notificationCounts = _.values(_state.notificationsByTeamId);
-			return notificationCounts.reduce(function sumNotificationCounts (sum, notificationCount) {
-				return sum + (notificationCount || 0);
-			}, 0);
+		getNotificationSummary: function () {
+			var notificationInfos = _.values(_state.notificationsByTeamId);
+			return notificationInfos.reduce(function sumNotificationCounts (sum, notificationInfo) {
+				sum.unreadCount += notificationInfo.unreadCount || 0;
+				sum.unreadHighlightsCount += notificationInfo.unreadHighlightsCount || 0;
+				return sum;
+			}, {unreadCount: 0, unreadHighlightsCount: 0});
 		},
-		setTeamNotifications: function (teamId, notificationCount) {
-			_state.notificationsByTeamId[teamId] = notificationCount;
+		setTeamNotifications: function (teamId, notificationInfo) {
+			_state.notificationsByTeamId[teamId] = notificationInfo;
 		},
 		unsetTeamNotifications: function (teamId) {
 			delete _state.notificationsByTeamId[teamId];
@@ -71,9 +73,13 @@
 		if (action.type === ActionTypes.NOTIFICATION_UPDATE) {
 			console.debug('Updating team notifications', {
 				teamId: action.teamId,
-				notificationCount: action.notificationCount
+				unreadCount: action.unreadCount,
+				unreadHighlightsCount: action.unreadHighlightsCount
 			});
-			NotificationStore.setTeamNotifications(action.teamId, action.notificationCount);
+			NotificationStore.setTeamNotifications(action.teamId, {
+				unreadCount: action.unreadCount,
+				unreadHighlightsCount: action.unreadHighlightsCount
+			});
 			NotificationStore.emitChange();
 		// When a team update occurs
 		} else if (action.type === ActionTypes.TEAMS_UPDATE) {


### PR DESCRIPTION
As reported in #93 and in #39, we are missing an "unread triangle/blob" and our notification count isn't accurate at the moment. This PR aims to make those accurate (and make `plaidchat` seem less noisy). In this PR:

- Broke down notifications into `unreadCount` and `unreadHighlightsCount`
- Added "unread" state for tray icon
- Capped highlight counts to "9+" as with Slack
- Added "unread triangle" to team sidebar
- Caught/patched bug with inactive iframes acknowledging notifications

![selection_146](https://cloud.githubusercontent.com/assets/902488/8373275/e78210c8-1bb0-11e5-9f83-ed8af30a7868.png)

![selection_145](https://cloud.githubusercontent.com/assets/902488/8373278/eaeef67c-1bb0-11e5-85cd-0182895e704f.png)

/cc @wlaurance 