### PR TITLE
Added support for GITHUB_TOKEN in `release.sh`

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -25,10 +25,26 @@ npm version "$version"
 # Grab our new semver
 semver="$(node --eval "console.log('v' + require('./package.json').version);")"
 
+# If we have a GITHUB_TOKEN environment variable, generate a `--token` flag for `github-changes`
+token_option=""
+if test -n "$GITHUB_TOKEN"; then
+	token_option="--token \"$GITHUB_TOKEN\""
+fi
+
 # Generate a new CHANGELOG
+# DEV: `$token_option` is multiple parameters so don't wrap it in quotes
+set +e
 ./node_modules/.bin/github-changes --title "plaidchat changelog" \
+	$token_option \
 	--owner plaidchat --repository plaidchat \
 	--only-pulls --use-commit-body -n "$semver"
+if test "$?" != "0"; then
+	echo "Failed to generate CHANGELOG. Probably due to a rate limit error." 1>&2
+	echo "To repair this, please generate a GitHub API token (\`public_repo\` only) and run \`GITHUB_TOKEN={{token}} ./release.sh\`" 1>&2
+	echo "Tokens can be generated here: https://github.com/settings/tokens" 1>&2
+	exit 1
+fi
+set -e
 
 # DEV: Add trailing newline for linter
 echo >> CHANGELOG.md


### PR DESCRIPTION
We have started to run into needing higher API thresholds for our releases. This PR adds support for passing a GitHub token to `release.sh` in order to faciliate higher limits. In this PR:

- Updated `release.sh` to support `GITHUB_TOKEN`

/cc @wlaurance 