### PR TITLE
Moved to new Slack login URL

### DIFF
--- a/app/stores/team.js
+++ b/app/stores/team.js
@@ -9,7 +9,7 @@
 
 	// Define constants
 	var CHANGE_EVENT = 'change';
-	var SLACK_LOGIN_URL = 'https://login.slack.com/';
+	var SLACK_LOGIN_URL = 'https://slack.com/signin';
 
 	// Define our internal storage system
 	var _state;

--- a/test/team-store.js
+++ b/test/team-store.js
@@ -51,7 +51,7 @@
 			var teams = this.store.getTeams();
 			expect(teams).to.have.length(1);
 			expect(teams[0]).to.have.property('team_id', '_plaidchat-placeholder-0');
-			expect(teams[0]).to.have.property('team_url', 'https://login.slack.com/');
+			expect(teams[0]).to.have.property('team_url', 'https://slack.com/signin');
 		});
 	});
 


### PR DESCRIPTION
As reported in #103, our login for fresh installs has broken. It turns out Slack has updated their login URL to allow supporting teams named "login". In this PR:

- Moved to new Slack login URL
- Fixes #103 

**Notes:**

Since this is high priority, I am going to cowboy land this.

/cc @wlaurance 