### PR TITLE
Added tests and repaired team management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,25 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
+
+install:
+  # Install our node dependencies
+  - npm install
+
+  # Install webdriver dependencies
+  # DEV: We run this here to avoid race conditions (e.g. Selenium not started) in testing
+  - bin/install-webdriver-dependencies.sh
+
+script:
+  # Set our display to :99 and start a mock X11 server
+  - export DISPLAY=":99"
+  - Xvfb "$DISPLAY" &> /dev/null &
+
+  # Start a Selenium server for our integration tests
+  - npm run start-webdriver &> /dev/null &
+
+  # Wait for Selenium to start
+  - bin/wait-for-selenium.sh
+
+  # Run all our tests
+  - npm test

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function (grunt) {
 
 	grunt.initConfig({
 		jshint: {
-			all: ['*.js', 'app/js/*.js'],
+			all: ['*.js', 'app/js/*.js', 'test/**/*.js'],
 			jshintrc: '.jshintrc'
 		},
 		jscs: {
@@ -19,7 +19,7 @@ module.exports = function (grunt) {
 		},
 		lintspaces: {
 			src: [
-				'*', 'app/**/*',
+				'*', 'app/**/*', 'test/**/*',
 				'!**/*.png', // Exclude images to prevent odd errors
 				'!README.md' // Exclude README due to CLI indentation
 			],

--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ More information can be read in the Flux documentation:
 
 <http://facebook.github.io/flux/>
 
+Testing
+=======
+Tests can be run via the following commands:
+
+```bash
+# Start up a Selenium server for integration tests
+npm run start-webdriver
+
+# In another tab, run all our tests (unit, integration, linting)
+npm test
+```
+
+The integration tests require a bit of explanation. Please see [their documentation for more info][integration-tests-docs].
+
+[integration-tests-docs]: test/integration-tests/README.md
+
 Issues
 ======
 libudev.so

--- a/app/components/slack-application.js
+++ b/app/components/slack-application.js
@@ -82,7 +82,8 @@
 					return React.createElement(SlackWindow, {
 						active: team.team_id === activeTeamId,
 						key: teamIndicies[team.team_id],
-						team: team
+						team: team,
+						teams: teams
 					});
 				}))
 			]);

--- a/app/components/team-sidebar.js
+++ b/app/components/team-sidebar.js
@@ -9,6 +9,13 @@
 		// Name to refer to elements by inside of React
 		displayName: 'team-sidebar',
 
+		// Helper for finding non-placeholder teams
+		getNonPlaceholderTeams: function () {
+			return this.props.teams.filter(function filterPlaceholderTeam (team) {
+				return team.is_placeholder !== true;
+			});
+		},
+
 		// Inform react to expect this data schema
 		propTypes: {
 			activeTeamId: React.PropTypes.string,
@@ -33,11 +40,12 @@
 
 		// Render our sidebar with active icons
 		render: function () {
+			var nonPlaceholderTeams = this.getNonPlaceholderTeams();
 			var props = this.props;
 			var _onClick = this._onClick;
 			return React.DOM.div({
-				className: props.teams.length >= 2 ? 'team-sidebar' : 'team-sidebar hidden'
-			}, props.teams.map(function createTeamRow (team) {
+				className: nonPlaceholderTeams.length >= 2 ? 'team-sidebar' : 'team-sidebar hidden'
+			}, nonPlaceholderTeams.map(function createTeamRow (team) {
 				var teamIcon = props.teamIcons[team.team_id];
 				var notificationInfo = props.notificationsByTeamId[team.team_id];
 				var unreadHighlightsCount = notificationInfo ? notificationInfo.unreadHighlightsCount : 0;

--- a/app/dispatchers/app.js
+++ b/app/dispatchers/app.js
@@ -11,6 +11,7 @@
 	// DEV: keyMirror copies keys to values (e.g. `{TEAMS_UPDATE: 'TEAMS_UPDATE'}`)
 	dispatcher.ActionTypes = keyMirror({
 		ACTIVATE_TEAM: true,
+		ADD_TEAM_REQUESTED: true,
 		APPLICATION_INIT: true,
 		NOTIFICATION_UPDATE: true,
 		TEAMS_UPDATE: true

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -14,6 +14,11 @@
 	var win = gui.Window.get();
 	var SLACK_DOWNLOAD_HOSTNAME = 'files.slack.com';
 
+	// If we are in a test environment, clear out localStorage
+	if (process.env.NODE_ENV === 'test') {
+		localStorage.clear();
+	}
+
 	// Interpet our CLI arguments
 	// DEV: We need to coerce `nw.js'` arguments as `commander` expects normal (`['node', 'plaidchat', '--help']`)
 	//   but `nw.js` only provides arguments themselves (e.g. `--help`)
@@ -21,6 +26,8 @@
 	program
 		.version(pkg.version)
 		.option('--minimize-to-tray', 'When the tray icon is clicked, hide the window rather than minimize')
+		// Allow unknown Chromium flags (used by integration tests)
+		.allowUnknownOption()
 		.parse(argv);
 
 	win.on('new-win-policy', function (frame, urlStr, policy) {

--- a/app/stores/team.js
+++ b/app/stores/team.js
@@ -9,7 +9,8 @@
 
 	// Define constants
 	var CHANGE_EVENT = 'change';
-	var SLACK_LOGIN_URL = 'https://slack.com/signin';
+	var SLACK_LOGIN_URL = process.env.NODE_ENV !== 'test' ? 'https://slack.com/signin' :
+		'file://' + __dirname + '/../../test/integration-tests/test-server/signin.html';
 
 	// Define our internal storage system
 	var _state;

--- a/bin/install-webdriver-dependencies.sh
+++ b/bin/install-webdriver-dependencies.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Exit on the first error
+set -e
+
+# Verify we have a Selenium jar downloaded
+if ! test -e ./node_modules/nw/nwjs/selenium.jar; then
+  ./node_modules/.bin/webdriver-manager update --standalone
+  # e.g. node_modules/webdriver-manager/selenium/selenium-server-standalone-2.46.0.jar
+  selenium_path="$(ls node_modules/webdriver-manager/selenium/selenium-*.jar)"
+  # Target path: `../../../node_modules/webdriver-manager/selenium/selenium-server-standalone-2.46.0.jar`
+  #   from perspective of `./node_modules/nw/nwjs/selenium.jar`
+  ln -s "../../../$selenium_path" ./node_modules/nw/nwjs/selenium.jar
+fi
+
+# Verify we have nw.js' Chromedriver installed
+if ! test -f ./node_modules/nw/nwjs/chromedriver; then
+  # Download and extract Chromedriver
+  mkdir -p tmp/
+  cd tmp/
+  wget http://dl.nwjs.io/v0.12.2/chromedriver-nw-v0.12.2-linux-x64.tar.gz
+  tar xzf chromedriver-nw-v0.12.2-linux-x64.tar.gz
+
+  # Copy over our Chromedriver for nw.js
+  cd ../
+  cp tmp/chromedriver-nw-v0.12.2-linux-x64/chromedriver node_modules/nw/nwjs/
+fi

--- a/bin/start-webdriver.sh
+++ b/bin/start-webdriver.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Exit on the first error
+set -e
+
+# Install any missing dependencies
+bin/install-webdriver-dependencies.sh
+
+# Start our webdriver instance
+export NODE_ENV=test
+java -jar ./node_modules/nw/nwjs/selenium.jar -Dwebdriver.chrome.driver=./node_modules/nw/nwjs/chromedriver

--- a/bin/wait-for-selenium.sh
+++ b/bin/wait-for-selenium.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Exit on the first error
+set -e
+
+# Attempt to connect to Selenium every 100ms or fail
+timeout 10s sh -c\
+  "while ! curl --silent http://localhost:4444/ > /dev/null; do
+    echo \"Waiting for Selenium to start...\" && sleep 0.1;
+  done"\
+ || exit 1

--- a/package.json
+++ b/package.json
@@ -39,22 +39,30 @@
   ],
   "scripts": {
     "build": "mkdir -p dist/js/ 2> /dev/null; browserify app/js/react.js -o dist/js/react.js",
+    "integration-test": "npm run verify-webdriver-running && mocha --timeout 10000 test/integration-tests/",
+    "lint": "grunt lint",
     "start": "node ./run.js",
-    "test": "mocha && grunt lint",
-    "postinstall": "./postinstall.sh"
+    "start-webdriver": "bin/start-webdriver.sh",
+    "test": "npm run unit-test && npm run integration-test && npm run lint",
+    "unit-test": "mocha test/unit-tests/",
+    "postinstall": "./postinstall.sh",
+    "verify-webdriver-running": "curl --silent http://localhost:4444/ > /dev/null || (echo \"Selenium server was not found. Please start it via \\`npm run start-webdriver\\`\" 1>&2 && exit 1)"
   },
   "bin": {
     "plaidchat": "./run.js"
   },
   "devDependencies": {
     "chai": "^3.0.0",
+    "function-to-string": "^0.2.0",
     "github-changes": "^1.0.0",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-jscs": "^1.1.0",
     "grunt-lintspaces": "^0.6.0",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "wd": "^0.3.12",
+    "webdriver-manager": "^6.0.0"
   },
   "single-instance": true,
   "window": {

--- a/test/integration-tests/README.md
+++ b/test/integration-tests/README.md
@@ -1,0 +1,8 @@
+# plaidchat integration tests
+Testing a full [nw.js][] can be quite tricky. This document is here to help you get your bearings and understand the purpose of each part.
+
+## Architecture
+- `*.js` - These are tests for specific functions of `plaidchat`
+- `utils/` - These are utilities used by tests (e.g. starting up an nw.js instance, finding an active window in `plaidchat`)
+- `test-server/` - These are static files used to mock the internals of the Slack web client
+    - We don't need the full client experience but we need to mock over how `plaidchat` interacts with it

--- a/test/integration-tests/README.md
+++ b/test/integration-tests/README.md
@@ -6,3 +6,11 @@ Testing a full [nw.js][] can be quite tricky. This document is here to help you 
 - `utils/` - These are utilities used by tests (e.g. starting up an nw.js instance, finding an active window in `plaidchat`)
 - `test-server/` - These are static files used to mock the internals of the Slack web client
     - We don't need the full client experience but we need to mock over how `plaidchat` interacts with it
+
+## Debugging
+In order to debug the state of a window for a failing test, we can tell `mocha` to not kill the browser instance. To do this, add a `killBrowser: false` option to `openPlaidchat`:
+
+```js
+// Allows mocha to run but doesn't clean up window after test fails
+browserUtils.openPlaidchat({killBrowser: false});
+```

--- a/test/integration-tests/login.js
+++ b/test/integration-tests/login.js
@@ -5,8 +5,8 @@ var browserUtils = require('./utils/browser');
 // Start our tests
 describe('A fresh plaidchat client', function () {
 	browserUtils.openPlaidchat();
-	browserUtils.execute(function getActiveWindowText () {
-		return window.getActiveWindow().document.body.textContent;
+	browserUtils.execute(function getActiveContentWindowText () {
+		return window.getActiveContentWindow().document.body.textContent;
 	});
 
 	it('arrives at a login screen', function () {
@@ -16,10 +16,10 @@ describe('A fresh plaidchat client', function () {
 
 	describe('upon successful login', function () {
 		browserUtils.execute(function loginToTeam () {
-			return window.getActiveWindow().signInToTeam('plaidchat1');
+			return window.getActiveContentWindow().signInToTeam('plaidchat1');
 		});
-		browserUtils.execute(function getActiveWindowLocation () {
-			return window.getActiveWindow().location.href;
+		browserUtils.execute(function getActiveContentWindowLocation () {
+			return window.getActiveContentWindow().location.href;
 		});
 
 		it('navigates to our team page', function () {
@@ -27,13 +27,110 @@ describe('A fresh plaidchat client', function () {
 		});
 
 		describe('with respect to the sidebar', function () {
-			browserUtils.execute(function getActiveWindowLocation () {
+			browserUtils.execute(function getActiveContentWindowLocation () {
 				var sidebar = document.getElementsByClassName('team-sidebar')[0];
 				return sidebar.classList;
 			});
 
 			it('has no sidebar', function () {
 				expect(this.result).to.contain('hidden');
+			});
+		});
+	});
+});
+
+describe('A plaidchat client signed in to 1 team', function () {
+	browserUtils.openPlaidchat();
+	browserUtils.execute(function loginToTeam () {
+		return window.getActiveContentWindow().signInToTeam('plaidchat1');
+	});
+
+	describe('logging into another team via the "Sign in to another team..." link', function () {
+		before(function waitForReactToProcessEvents (done) {
+			setTimeout(done, 100);
+		});
+		browserUtils.execute(function navigateToSignInPage () {
+			return window.getActiveContentWindow().document.getElementById('signin-link').click();
+		});
+
+		describe('with respect to the active window', function () {
+			browserUtils.execute(function getActiveContentWindowText () {
+				return window.getActiveContentWindow().document.body.textContent;
+			});
+
+			it('is pointing to the sign in page', function () {
+				var iframeText = this.result;
+				expect(iframeText).to.contain('Mock sign in page');
+			});
+		});
+
+		describe('with respect to the sidebar', function () {
+			browserUtils.execute(function getSidebarInfo () {
+				var sidebar = document.getElementsByClassName('team-sidebar')[0];
+				return sidebar.classList;
+			});
+
+			it('is not visible', function () {
+				expect(this.result).to.contain('hidden');
+			});
+		});
+
+		describe('with respect to hidden windows', function () {
+			browserUtils.execute(function getHiddenWindowLocations () {
+				return window.getHiddenWindowLocations();
+			});
+
+			it('the `plaidchat1` team exists but is not visible', function () {
+				expect(this.result).to.have.length(1);
+				expect(this.result[0]).to.match(/team.html\?plaidchat1$/);
+			});
+		});
+
+		describe('upon succesful sign in to another team', function () {
+			browserUtils.execute(function loginToTeam () {
+				return window.getActiveContentWindow().signInToTeams([/* active: */ 'plaidchat2', /* inactive: */ 'plaidchat1']);
+			});
+
+			describe('with respect to the active window', function () {
+				browserUtils.execute(function getActiveContentWindowLocation () {
+					return window.getActiveContentWindow().location.href;
+				});
+
+				it('is showing the new team', function () {
+					expect(this.result).to.match(/team.html\?plaidchat2/);
+				});
+			});
+
+			describe('with respect to the sidebar', function () {
+				browserUtils.execute(function getSidebarInfo () {
+					var sidebar = document.getElementsByClassName('team-sidebar')[0];
+					return {
+						sidebarClassList: sidebar.classList,
+						iconSrcArr: [].map.call(sidebar.getElementsByTagName('img'), function getSrc (imgEl) {
+							return imgEl.src;
+						}),
+						rowClassListArr: [].map.call(sidebar.querySelectorAll('.team-sidebar__row'), function getClassList (rowEl) {
+							return rowEl.classList;
+						})
+					};
+				});
+
+				it('is visible', function () {
+					expect(this.result.sidebarClassList).to.not.contain('hidden');
+				});
+
+				it('shows both teams', function () {
+					expect(this.result.iconSrcArr).to.deep.equal([
+						'http://lorempixel.com/44/44/abstract/1/?plaidchat1',
+						'http://lorempixel.com/44/44/abstract/1/?plaidchat2'
+					]);
+				});
+
+				// TODO: Relocate to sidebar specific tests
+				it('marks the second team as active', function () {
+					expect(this.result.rowClassListArr[0]).to.not.contain('team-sidebar__row--active');
+					expect(this.result.rowClassListArr[1]).to.contain('team-sidebar__row--active');
+				});
 			});
 		});
 	});

--- a/test/integration-tests/login.js
+++ b/test/integration-tests/login.js
@@ -1,0 +1,40 @@
+// Load in dependencies
+var expect = require('chai').expect;
+var browserUtils = require('./utils/browser');
+
+// Start our tests
+describe('A fresh plaidchat client', function () {
+	browserUtils.openPlaidchat();
+	browserUtils.execute(function getActiveWindowText () {
+		return window.getActiveWindow().document.body.textContent;
+	});
+
+	it('arrives at a login screen', function () {
+		var iframeText = this.result;
+		expect(iframeText).to.contain('Mock sign in page');
+	});
+
+	describe('upon successful login', function () {
+		browserUtils.execute(function loginToTeam () {
+			return window.getActiveWindow().signInToTeam('plaidchat1');
+		});
+		browserUtils.execute(function getActiveWindowLocation () {
+			return window.getActiveWindow().location.href;
+		});
+
+		it('navigates to our team page', function () {
+			expect(this.result).to.match(/team.html\?plaidchat1$/);
+		});
+
+		describe('with respect to the sidebar', function () {
+			browserUtils.execute(function getActiveWindowLocation () {
+				var sidebar = document.getElementsByClassName('team-sidebar')[0];
+				return sidebar.classList;
+			});
+
+			it('has no sidebar', function () {
+				expect(this.result).to.contain('hidden');
+			});
+		});
+	});
+});

--- a/test/integration-tests/team-management-sidebar.js
+++ b/test/integration-tests/team-management-sidebar.js
@@ -1,0 +1,103 @@
+// Load in dependencies
+var expect = require('chai').expect;
+var browserUtils = require('./utils/browser');
+
+// Start our tests
+describe('A plaidchat client signed in to 2 teams', function () {
+	browserUtils.openPlaidchat();
+	browserUtils.execute(function loginToTeam () {
+		return window.getActiveContentWindow().signInToTeams(['plaidchat1', 'plaidchat2']);
+	});
+
+	describe('logging into another team via the "Sign in to another team..." link', function () {
+		before(function waitForReactToProcessEvents (done) {
+			setTimeout(done, 100);
+		});
+		browserUtils.execute(function setOriginalMarker () {
+			window.getContentWindowByTeamName('plaidchat1').hello = 'world';
+		});
+		browserUtils.execute(function navigateToSignInPage () {
+			return window.getActiveContentWindow().document.getElementById('signin-link').click();
+		});
+
+		describe('upon navigating back to the first team via the sidebar', function () {
+			before(function waitForReactToProcessEvents (done) {
+				setTimeout(done, 100);
+			});
+			browserUtils.execute(function clickFirstTeamSidebar () {
+				return document.querySelector('img[src$=plaidchat1]').click();
+			});
+
+			describe('with respect to the active window', function () {
+				browserUtils.execute(function getOriginalMarker () {
+					return window.getActiveContentWindow().hello;
+				});
+				it('does not reload the first team\'s page', function () {
+					expect(this.result).to.equal('world');
+				});
+			});
+
+			// TODO: Repair this behavior as it causes leaks
+			describe.skip('with respect to the hidden windows', function () {
+				browserUtils.execute(function getHiddenWindowLocations () {
+					return window.getHiddenWindowLocations();
+				});
+
+				it('has no extra windows (i.e. the placeholder was cleaned up)', function () {
+					expect(this.result).to.have.length(1);
+					expect(this.result[0]).to.match(/team.html\?plaidchat2/);
+				});
+			});
+		});
+	});
+});
+
+describe('A plaidchat client signed in to 2 teams', function () {
+	browserUtils.openPlaidchat();
+	browserUtils.execute(function loginToTeam () {
+		return window.getActiveContentWindow().signInToTeams(['plaidchat1', 'plaidchat2']);
+	});
+
+	describe('logging into another team via the "Sign in to another team..." link', function () {
+		before(function waitForReactToProcessEvents (done) {
+			setTimeout(done, 100);
+		});
+		browserUtils.execute(function setOriginalMarker () {
+			window.getContentWindowByTeamName('plaidchat2').hello = 'world';
+		});
+		browserUtils.execute(function navigateToSignInPage () {
+			return window.getActiveContentWindow().document.getElementById('signin-link').click();
+		});
+
+		describe('upon navigating back to the second team via the sidebar', function () {
+			before(function waitForReactToProcessEvents (done) {
+				setTimeout(done, 100);
+			});
+			browserUtils.execute(function clickSecondTeamSidebar () {
+				return document.querySelector('img[src$=plaidchat2]').click();
+			});
+
+			describe('with respect to the active window', function () {
+				browserUtils.execute(function getOriginalMarker () {
+					return window.getActiveContentWindow().hello;
+				});
+
+				it('does not reload the second team\'s page', function () {
+					expect(this.result).to.equal('world');
+				});
+			});
+
+			// TODO: Repair this behavior as it causes leaks
+			describe.skip('with respect to the hidden windows', function () {
+				browserUtils.execute(function getHiddenWindowLocations () {
+					return window.getHiddenWindowLocations();
+				});
+
+				it('has no extra windows (i.e. the placeholder was cleaned up)', function () {
+					expect(this.result).to.have.length(1);
+					expect(this.result[0]).to.match(/team.html\?plaidchat1/);
+				});
+			});
+		});
+	});
+});

--- a/test/integration-tests/team-management-signin-link.js
+++ b/test/integration-tests/team-management-signin-link.js
@@ -1,0 +1,156 @@
+// Load in dependencies
+var expect = require('chai').expect;
+var browserUtils = require('./utils/browser');
+
+// Start our tests
+describe('A plaidchat client signed in to 1 team', function () {
+	browserUtils.openPlaidchat();
+	browserUtils.execute(function loginToTeam () {
+		return window.getActiveContentWindow().signInToTeam('plaidchat1');
+	});
+
+	describe('logging into another team via the "Sign in to another team..." link', function () {
+		before(function waitForReactToProcessEvents (done) {
+			setTimeout(done, 100);
+		});
+		browserUtils.execute(function setOriginalMarker () {
+			window.getActiveContentWindow().hello = 'world';
+		});
+		browserUtils.execute(function navigateToSignInPage () {
+			return window.getActiveContentWindow().document.getElementById('signin-link').click();
+		});
+
+		describe('upon navigating back to the original team via signin link', function () {
+			browserUtils.execute(function loginToOriginalTeam () {
+				return window.getActiveContentWindow().signInToTeam('plaidchat1');
+			});
+
+			describe('with respect to the active window', function () {
+				browserUtils.execute(function getOriginalMarker () {
+					return window.getActiveContentWindow().hello;
+				});
+
+				it('does not reload the original page', function () {
+					expect(this.result).to.equal('world');
+				});
+			});
+
+			describe('with respect to the sidebar', function () {
+				browserUtils.execute(function getSidebarInfo () {
+					var sidebar = document.getElementsByClassName('team-sidebar')[0];
+					return sidebar.classList;
+				});
+
+				it('is not visible', function () {
+					expect(this.result).to.contain('hidden');
+				});
+			});
+
+			describe('with respect to the hidden windows', function () {
+				browserUtils.execute(function getHiddenWindowLocations () {
+					return window.getHiddenWindowLocations();
+				});
+
+				it('has no extra windows (i.e. the placeholder was cleaned up)', function () {
+					expect(this.result).to.have.length(0);
+				});
+			});
+		});
+	});
+});
+
+describe('A plaidchat client signed in to 2 teams', function () {
+	browserUtils.openPlaidchat();
+	browserUtils.execute(function loginToTeam () {
+		return window.getActiveContentWindow().signInToTeams(['plaidchat1', 'plaidchat2']);
+	});
+
+	describe('logging into another team via the "Sign in to another team..." link', function () {
+		before(function waitForReactToProcessEvents (done) {
+			setTimeout(done, 100);
+		});
+		browserUtils.execute(function setOriginalMarker () {
+			window.getContentWindowByTeamName('plaidchat1').hello = 'world';
+		});
+		browserUtils.execute(function navigateToSignInPage () {
+			return window.getActiveContentWindow().document.getElementById('signin-link').click();
+		});
+
+		describe('upon navigating back to the first team via the links on the sign in page', function () {
+			before(function waitForReactToProcessEvents (done) {
+				setTimeout(done, 100);
+			});
+			browserUtils.execute(function loginToTeam () {
+				return window.getActiveContentWindow().signInToTeams(['plaidchat1', 'plaidchat2']);
+			});
+
+			describe('with respect to the active window', function () {
+				browserUtils.execute(function getOriginalMarker () {
+					return window.getActiveContentWindow().hello;
+				});
+				it('does not reload the first team\'s page', function () {
+					expect(this.result).to.equal('world');
+				});
+			});
+
+			describe('with respect to the hidden windows', function () {
+				browserUtils.execute(function getHiddenWindowLocations () {
+					return window.getHiddenWindowLocations();
+				});
+
+				it('has no extra windows (i.e. the placeholder was cleaned up)', function () {
+					expect(this.result).to.have.length(1);
+					expect(this.result[0]).to.match(/team.html\?plaidchat2/);
+				});
+			});
+		});
+	});
+});
+
+describe('A plaidchat client signed in to 2 teams', function () {
+	browserUtils.openPlaidchat();
+	browserUtils.execute(function loginToTeam () {
+		return window.getActiveContentWindow().signInToTeams(['plaidchat1', 'plaidchat2']);
+	});
+
+	describe('logging into another team via the "Sign in to another team..." link', function () {
+		before(function waitForReactToProcessEvents (done) {
+			setTimeout(done, 100);
+		});
+		browserUtils.execute(function setOriginalMarker () {
+			window.getContentWindowByTeamName('plaidchat2').hello = 'world';
+		});
+		browserUtils.execute(function navigateToSignInPage () {
+			return window.getActiveContentWindow().document.getElementById('signin-link').click();
+		});
+
+		describe('upon navigating back to the second team via the links on the sign in page', function () {
+			before(function waitForReactToProcessEvents (done) {
+				setTimeout(done, 100);
+			});
+			browserUtils.execute(function loginToTeam () {
+				return window.getActiveContentWindow().signInToTeams(['plaidchat2', 'plaidchat1'], {useLink: true});
+			});
+
+			describe('with respect to the active window', function () {
+				browserUtils.execute(function getOriginalMarker () {
+					return window.getActiveContentWindow().hello;
+				});
+				it('does not reload the second team\'s page', function () {
+					expect(this.result).to.equal('world');
+				});
+			});
+
+			describe.skip('with respect to the hidden windows', function () {
+				browserUtils.execute(function getHiddenWindowLocations () {
+					return window.getHiddenWindowLocations();
+				});
+
+				it('has no extra windows (i.e. the placeholder was cleaned up)', function () {
+					expect(this.result).to.have.length(1);
+					expect(this.result[0]).to.match(/team.html\?plaidchat1/);
+				});
+			});
+		});
+	});
+});

--- a/test/integration-tests/team-management-switch-link.js
+++ b/test/integration-tests/team-management-switch-link.js
@@ -1,0 +1,83 @@
+// Load in dependencies
+var expect = require('chai').expect;
+var browserUtils = require('./utils/browser');
+
+// Start our tests
+describe('A plaidchat client signed in to 2 teams', function () {
+	browserUtils.openPlaidchat();
+	browserUtils.execute(function loginToTeam () {
+		return window.getActiveContentWindow().signInToTeams(['plaidchat1', 'plaidchat2']);
+	});
+
+	describe('upon switching to another via the "Switch to team" links', function () {
+		before(function waitForReactToProcessEvents (done) {
+			setTimeout(done, 100);
+		});
+		browserUtils.execute(function setOriginalMarkers () {
+			window.getContentWindowByTeamName('plaidchat1').hello = 'world';
+			window.getContentWindowByTeamName('plaidchat2').goodbye = 'moon';
+		});
+		browserUtils.execute(function switchTeams () {
+			return window.getActiveContentWindow().document.querySelector('a[href*=\'team.html?plaidchat2\']').click();
+		});
+
+		describe('with respect to the active window', function () {
+			browserUtils.execute(function getActiveContentWindowLocation () {
+				return window.getActiveContentWindow().location.href;
+			});
+
+			it('changes the active team', function () {
+				expect(this.result).to.match(/team.html\?plaidchat2/);
+			});
+		});
+
+		describe('with respect to the first team', function () {
+			browserUtils.execute(function setOriginalMarker () {
+				return window.getContentWindowByTeamName('plaidchat1').hello;
+			});
+
+			it('still has a page page and doesn\'t reload it', function () {
+				// DEV: If there was no window, then we wouldn't have a property
+				expect(this.result).to.equal('world');
+			});
+		});
+
+		describe('with respect to the second team', function () {
+			browserUtils.execute(function setOriginalMarker () {
+				return window.getActiveContentWindow().goodbye;
+			});
+
+			it('does not reload the second team\'s page', function () {
+				expect(this.result).to.equal('moon');
+			});
+		});
+	});
+});
+
+// DEV: This is to prevent an edge case of blocking same-site link switches
+describe('A plaidchat client signed in to 1 team', function () {
+	browserUtils.openPlaidchat();
+	browserUtils.execute(function loginToTeam () {
+		return window.getActiveContentWindow().signInToTeam('plaidchat1');
+	});
+
+	describe('upon switching to another page in our team', function () {
+		before(function waitForReactToProcessEvents (done) {
+			setTimeout(done, 100);
+		});
+		browserUtils.execute(function navigateToAnotherPage () {
+			return window.getActiveContentWindow().document.querySelector('a[href*=\'team.html?plaidchat1\']').click();
+		});
+
+		describe('with respect to the active window', function () {
+			browserUtils.execute(function getActiveContentWindowLocation () {
+				return window.getActiveContentWindow().location.href;
+			});
+
+			it('moves to the next page', function () {
+				expect(this.result).to.match(/team.html\?plaidchat1/);
+				expect(this.result).to.match(/#customize/);
+			});
+		});
+	});
+});

--- a/test/integration-tests/test-server/signin.html
+++ b/test/integration-tests/test-server/signin.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>plaidchat test - Mock sign in page</title>
+</head>
+<body>
+  <h1>Mock sign in page</h1>
+  <p>Everything is controlled via JS. Otherwise, we be testing our own test code which is silly (e.g. filling out our own forms).</p>
+  <script>
+    window.signInToTeam = function (teamName) {
+      window.location = window.location + '/../team.html?' + encodeURIComponent(teamName);
+    };
+  </script>
+</body>
+</html>

--- a/test/integration-tests/test-server/signin.html
+++ b/test/integration-tests/test-server/signin.html
@@ -6,9 +6,24 @@
 <body>
   <h1>Mock sign in page</h1>
   <p>Everything is controlled via JS. Otherwise, we be testing our own test code which is silly (e.g. filling out our own forms).</p>
+  <a id="js-link" href="#">JavaScript controlled sign in link</a>
   <script>
-    window.signInToTeam = function (teamName) {
-      window.location = window.location + '/../team.html?' + encodeURIComponent(teamName);
+    var linkEl = document.getElementById('js-link');
+    window.signInToTeam = function (teamName, options) {
+      window.signInToTeams([teamName], options);
+    };
+    // DEV: Sign into the first team as the active one with all others as inactive
+    // This removes the need for maintaining state and mockk Slack (effectively testing our tests)
+    window.signInToTeams = function (teamNames, options) {
+      options = options || {};
+      var file = 'team.html?' + encodeURIComponent(teamNames.join(','));
+      if (options.useLink) {
+        // DEV: We use a link/click to emulate potentially clicking a "Switch" link in Slack
+        linkEl.href = file;
+        linkEl.click();
+      } else {
+        window.location = window.location + '/../' + file;
+      }
     };
   </script>
 </body>

--- a/test/integration-tests/test-server/team.html
+++ b/test/integration-tests/test-server/team.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>plaidchat test - Mock team page</title>
+</head>
+<body>
+  <h1>Mock team page</h1>
+  <p>Everything is controlled via JS. Otherwise, we be testing our own test code which is silly (e.g. filling out our own forms).</p>
+</body>
+</html>

--- a/test/integration-tests/test-server/team.html
+++ b/test/integration-tests/test-server/team.html
@@ -4,7 +4,84 @@
   <title>plaidchat test - Mock team page</title>
 </head>
 <body>
-  <h1>Mock team page</h1>
+  <script>
+    // Grab our team name from the URL (e.g. `team.html?plaidchat1,plaidchat2` -> `[plaidchat1, plaidchat2]`)
+    var queryString = decodeURIComponent(window.location.search.slice(1));
+    window._teamNames = queryString.split(/,/g);
+    window._teamName = window._teamNames[0];
+
+    // Generate full teams
+    window._teams = window._teamNames.map(function generateTeams (teamName, i) {
+      // Find the team order for this team (e.g. `pc1,pc2,pc3` -> `pc2,pc1,pc3` for `pc2`)
+      var thisTeams = window._teamNames.slice();
+      thisTeams.splice(i, 1);
+      thisTeams.unshift(teamName);
+      var teamUrl = window.location.origin + window.location.pathname +
+        '?' + encodeURIComponent(thisTeams.join(','));
+
+      // Create our team
+      var team = {
+        team_id: teamName, // e.g. plaidchat1
+        team_name: teamName, // e.g. plaidchat1
+        team_url: teamUrl,
+        team_icon: {
+          image_44: 'http://lorempixel.com/44/44/abstract/1/?' + encodeURIComponent(teamName)
+        }
+      };
+
+      // If this is the first team, then scrub it's images
+      // DEV: In Slack, we don't provide an image for the first team
+      if (i === 0) {
+        delete team.team_icon;
+      };
+
+      // Return our team
+      return team;
+    });
+  </script>
+  <!-- `document.write` is a bad practice but this helps us debug easily -->
+  <h1>Mock team page (<script>document.write(window._teamName);</script>)</h1>
   <p>Everything is controlled via JS. Otherwise, we be testing our own test code which is silly (e.g. filling out our own forms).</p>
+  <script>
+    window._teams.forEach(function generateTeamLink (team, i) {
+      // Generate our elements
+      var divEl = document.createElement('div');
+      var linkEl = document.createElement('a');
+      divEl.appendChild(linkEl);
+      document.body.appendChild(divEl);
+
+      // If this is the first team, add a customization link
+      if (i === 0) {
+        linkEl.href = team.team_url + '#customize';
+        linkEl.textContent = 'Customize ' + team.team_name;
+        return;
+      }
+
+      // Otherwise, add a link to sign in on the page
+      // DEV: We must use a non-exact match to mimic what Slack does
+      //   They use `https://plaidchat-test.slack.com/messages`
+      linkEl.href = team.team_url + '#messages';
+      linkEl.textContent = 'Switch to ' + team.team_name;
+    });
+  </script>
+  <div>
+    <a id="signin-link" href="signin.html">Sign in to another team...</a>
+  </div>
+  <script>
+    window.TS = {
+      getAllTeams: function () {
+        return window._teams.slice();
+      },
+      model: {
+        team: {
+          id: window._teamName, // e.g. plaidchat1
+          name: window._teamName, // e.g. plaidchat1
+          icon: {
+            image_44: 'http://lorempixel.com/44/44/abstract/1/?' + encodeURIComponent(window._teamName)
+          }
+        }
+      }
+    };
+  </script>
 </body>
 </html>

--- a/test/integration-tests/utils/browser.js
+++ b/test/integration-tests/utils/browser.js
@@ -1,0 +1,84 @@
+// Load in dependencies
+var assert = require('assert');
+var functionToString = require('function-to-string');
+var wd = require('wd');
+var definePlaidchatHelpers = require('./plaidchat-helpers');
+
+// Define helpers for interacting with the browser
+exports.openPlaidchat = function (options) {
+	// Fallback our options
+	options = options || {};
+
+	// Execute many async steps
+	before(function startBrowser () {
+		this.browser = wd.remote();
+		// DEV: To debug selenium interactions
+		//   Enable thes line
+		// global.browser = this.browser;
+		//    and run the following inside of a `node` repl
+		// process.exit = function () {};
+		// process.argv = ['node', '_mocha', '--timeout', '10000'];
+		// require('mocha/bin/_mocha');
+		//    when mocha is completed, access `browser` as a Selenium session
+	});
+	before(function openBrowser (done) {
+		this.browser.init({browserName: 'chrome'}, done);
+	});
+	before(function navigateToPlaidchat (done) {
+		// /plaidchat/test/integration-tests/utils/../../../app/views/index.html
+		var plaidchatUrl = 'file://' + __dirname + '/../../../app/views/index.html';
+		this.browser.get(plaidchatUrl, done);
+	});
+
+	// Add common helpers
+	exports.execute(definePlaidchatHelpers);
+
+	// If we want to want to kill the session, clean it up
+	// DEV: This is useful for inspecting state of a session
+	var killBrowser = options.killBrowser === undefined ? true : options.killBrowser;
+	if (killBrowser) {
+		after(function killBrowserFn (done) {
+			this.browser.quit(done);
+		});
+	}
+	after(function cleanup () {
+		delete this.browser;
+	});
+};
+
+// Helper to assert we have a browser started always
+exports.assertBrowser = function () {
+	before(function assertBrowserFn () {
+		assert(this.browser, '`this.browser` is not defined. Please make sure ' +
+			'`browserUtils.openPlaidchat()` has been run.');
+	});
+};
+
+exports.execute = function () {
+	// Save arguments in an array
+	var args = [].slice.call(arguments);
+
+	// If the first argument is a function, coerce it to a string
+	var evalFn = args[0];
+	if (typeof evalFn === 'function') {
+		args[0] = functionToString(evalFn).body;
+	}
+
+	// Run the mocha bindings
+	exports.assertBrowser();
+	before(function runExecute (done) {
+		// Add on a callback to the arguments
+		var that = this;
+		args.push(function handleResult (err, result) {
+			// Save the result and callback
+			that.result = result;
+			done(err);
+		});
+
+		// Execute our request
+		this.browser.execute.apply(this.browser, args);
+	});
+	after(function cleanup () {
+		delete this.result;
+	});
+};

--- a/test/integration-tests/utils/plaidchat-helpers.js
+++ b/test/integration-tests/utils/plaidchat-helpers.js
@@ -1,0 +1,15 @@
+// Generate a function that generates plaidchat helpers within the context of nw.js
+function definePlaidChatHelpers() {
+	// Load in assert in the context of nw.js
+	var assert = require('assert');
+
+	// Define global helpers in the context of nw.js
+	window.getActiveWindow = function () {
+		var activeIframes = document.getElementsByClassName('slack-window--active');
+		if (activeIframes.length !== 1) {
+			throw new Error('Expected only 1 active slack window but there were "' + activeIframes.length + '"');
+		}
+		return activeIframes[0].contentWindow;
+	};
+}
+module.exports = definePlaidChatHelpers;

--- a/test/integration-tests/utils/plaidchat-helpers.js
+++ b/test/integration-tests/utils/plaidchat-helpers.js
@@ -4,12 +4,40 @@ function definePlaidChatHelpers() {
 	var assert = require('assert');
 
 	// Define global helpers in the context of nw.js
-	window.getActiveWindow = function () {
+	window.getActiveContentWindow = function () {
 		var activeIframes = document.getElementsByClassName('slack-window--active');
 		if (activeIframes.length !== 1) {
 			throw new Error('Expected only 1 active slack window but there were "' + activeIframes.length + '"');
 		}
 		return activeIframes[0].contentWindow;
+	};
+	window.getAllWindows = function () {
+		return document.getElementsByClassName('slack-window');
+	};
+	window.getWindowByTeamName = function (teamName) {
+		var windows = window.getAllWindows();
+		var i = 0;
+		var len = windows.length;
+		for (; i < len; i++) {
+			var win = windows[i];
+			var contentWindow = win.contentWindow;
+			if (contentWindow.location.search.slice(1).indexOf(teamName) === 0) {
+				return win;
+			}
+		}
+		return null;
+	};
+	window.getContentWindowByTeamName = function (teamName) {
+		return window.getWindowByTeamName(teamName).contentWindow;
+	};
+	window.getHiddenWindows = function () {
+		return document.querySelectorAll('.slack-window:not(.slack-window--active)');
+	};
+	window.getHiddenWindowLocations = function () {
+		var hiddenSlackWindows = window.getHiddenWindows();
+		return [].map.call(hiddenSlackWindows, function saveWindowLocation (iframeEl) {
+			return iframeEl.contentWindow.location.href;
+		});
 	};
 }
 module.exports = definePlaidChatHelpers;

--- a/test/unit-tests/team-store.js
+++ b/test/unit-tests/team-store.js
@@ -2,8 +2,8 @@
 	'use strict';
 	// Load in our dependencies
 	var expect = require('chai').expect;
-	var AppDispatcher = require('../app/dispatchers/app');
-	var _TeamStore = require('../app/stores/team');
+	var AppDispatcher = require('../../app/dispatchers/app');
+	var _TeamStore = require('../../app/stores/team');
 
 	// Fallback console.debug to a noop
 	console.debug = function () {};


### PR DESCRIPTION
**Depends on #108**

First off, sorry for the large PR. This is mostly due to us adding all these tests at once. There are about 100 LoC for fixes themselves.

This PR adds in integration tests for team management (e.g. how we manage windows when signing in/switching between teams). Additionally, it patches the following issues:

- Updates sidebar upon sign in to new team
    - Fixes #96 
- Properly switches active team in sidebar when clicking "Switch to {{team name}}" link
- Properly handles clicking "Sign in to {{team name}}" link on "Sign in" page (usually arrive via navigating to "Sign into another team..." link)

The patches are:

- When a link is clicked in Slack window, if it's to the sign in page, then stop it and display a new Slack window sign in page instead
- When a link is clicked in Slack window, if it's to a known team, then stop it and switch that team's Slack window instead

Additional changes:

- Added more documentation for integration tests

/cc @wlaurance 