### PR TITLE
Moved to simplified Selenium configuration

### DIFF
--- a/bin/install-webdriver-dependencies.sh
+++ b/bin/install-webdriver-dependencies.sh
@@ -2,25 +2,5 @@
 # Exit on the first error
 set -e
 
-# Verify we have a Selenium jar downloaded
-if ! test -e ./node_modules/nw/nwjs/selenium.jar; then
-  ./node_modules/.bin/webdriver-manager update --standalone
-  # e.g. node_modules/webdriver-manager/selenium/selenium-server-standalone-2.46.0.jar
-  selenium_path="$(ls node_modules/webdriver-manager/selenium/selenium-*.jar)"
-  # Target path: `../../../node_modules/webdriver-manager/selenium/selenium-server-standalone-2.46.0.jar`
-  #   from perspective of `./node_modules/nw/nwjs/selenium.jar`
-  ln -s "../../../$selenium_path" ./node_modules/nw/nwjs/selenium.jar
-fi
-
-# Verify we have nw.js' Chromedriver installed
-if ! test -f ./node_modules/nw/nwjs/chromedriver; then
-  # Download and extract Chromedriver
-  mkdir -p tmp/
-  cd tmp/
-  wget http://dl.nwjs.io/v0.12.2/chromedriver-nw-v0.12.2-linux-x64.tar.gz
-  tar xzf chromedriver-nw-v0.12.2-linux-x64.tar.gz
-
-  # Copy over our Chromedriver for nw.js
-  cd ../
-  cp tmp/chromedriver-nw-v0.12.2-linux-x64/chromedriver node_modules/nw/nwjs/
-fi
+# Install our Selenium and nw specific Chromedriver
+webdriver-manager update --standalone true --chrome false --chromedriver-nw true

--- a/bin/start-webdriver.sh
+++ b/bin/start-webdriver.sh
@@ -7,4 +7,4 @@ bin/install-webdriver-dependencies.sh
 
 # Start our webdriver instance
 export NODE_ENV=test
-java -jar ./node_modules/nw/nwjs/selenium.jar -Dwebdriver.chrome.driver=./node_modules/nw/nwjs/chromedriver
+./node_modules/.bin/webdriver-manager start

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "grunt-lintspaces": "^0.6.0",
     "mocha": "^2.2.5",
     "wd": "^0.3.12",
-    "webdriver-manager": "^6.0.0"
+    "webdriver-manager": "^7.0.1"
   },
   "single-instance": true,
   "window": {

--- a/test/integration-tests/utils/browser.js
+++ b/test/integration-tests/utils/browser.js
@@ -1,8 +1,12 @@
 // Load in dependencies
 var assert = require('assert');
 var functionToString = require('function-to-string');
+var nw = require('nw');
 var wd = require('wd');
 var definePlaidchatHelpers = require('./plaidchat-helpers');
+
+// Eagerly find our nw patch
+var nwCmd = nw.findpath();
 
 // Define helpers for interacting with the browser
 exports.openPlaidchat = function (options) {
@@ -22,7 +26,12 @@ exports.openPlaidchat = function (options) {
 		//    when mocha is completed, access `browser` as a Selenium session
 	});
 	before(function openBrowser (done) {
-		this.browser.init({browserName: 'chrome'}, done);
+		this.browser.init({
+			browserName: 'chrome',
+			chromeOptions: {
+				binary: nwCmd
+			}
+		}, done);
 	});
 	before(function navigateToPlaidchat (done) {
 		// /plaidchat/test/integration-tests/utils/../../../app/views/index.html


### PR DESCRIPTION
`webdriver-manager` has added support for `nw.js' Chromedriver` which greatly simplifies our configuration. This PR upgrades to that and removes redundant code. In this PR:

- Simplified `webdriver-manager update`
- Used `webdriver-manager start` over bespoke command
- Added `nw` path passing to `wd` (as required)

/cc @wlaurance 