### PR TITLE
add info for cli flag option --force-device-scale-factor (helps with …

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ $ plaidchat --help
     --minimize-to-tray  When the tray icon is clicked, hide the window rather than minimize
     --close-to-tray     When the close button is clicked, minimize the app to tray instead of killing it.
 
+    --force-device-scale-factor=[value]
+                        Sets the UI scaling factor (default: 1, set to 2 for high-DPI)
+
 ```
 
 Running and Developing

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -27,6 +27,7 @@
 		.version(pkg.version)
 		.option('--minimize-to-tray', 'When the tray icon is clicked, hide the window rather than minimize')
 		.option('--close-to-tray', 'When the close button is clicked, minimize the app to tray instead of killing it.')
+		.option('--force-device-scale-factor=[value]', 'Sets the UI scaling factor (default: 1, set to 2 for high-DPI)')
 		// Allow unknown Chromium flags (used by integration tests)
 		.allowUnknownOption()
 		.parse(argv);
@@ -79,6 +80,9 @@
 		load: function () {
 			// Bind our app menu to the window
 			AppMenu.bindTo(win);
+			// DEV: AppMenu causes scaling problems (nw.gui, maybe?) when launching
+			//   with flag --force-device-scale-factor, for 2x scaling with high DPI
+			//   screens. Possibly add a launch flag to make this feature optional.
 
 			// Setup initial team
 			SlackApplication.loadInitialTeams();

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -80,9 +80,6 @@
 		load: function () {
 			// Bind our app menu to the window
 			AppMenu.bindTo(win);
-			// DEV: AppMenu causes scaling problems (nw.gui, maybe?) when launching
-			//   with flag --force-device-scale-factor, for 2x scaling with high DPI
-			//   screens. Possibly add a launch flag to make this feature optional.
 
 			// Setup initial team
 			SlackApplication.loadInitialTeams();


### PR DESCRIPTION
…high DPI displays and issue #77)

This isn't really a direct/optimal fix for zooming, but may inform the user of the ability to launch with UI scaling.

No real functional code added, here. Launching plaidchat with that flag is the only way to make it usable for me (on a 3200x1800 res, 13" and the app is tiiiiiny).

I wonder if nw.js has some better features or hooks to detect UI scaling.  I know all my other apps on Linux are sizing 2x to compensate for the high res.