### PR TITLE
Added in Quick Switcher team switch patch

### DIFF
--- a/app/stores/team.js
+++ b/app/stores/team.js
@@ -117,6 +117,13 @@
 			// Lookup and return our team by its id
 			return _state.teamsById[id];
 		},
+		getTeamByUserId: function (userId) {
+			// DEV: This isn't performant as we loop over rather than doing an index lookup
+			//   Maybe we should use a dictionary for tracking user ids as well?
+			var teams = _.values(_state.teamsById);
+			var team = _.findWhere(teams, {id: userId});
+			return team || null;
+		},
 		getTeamsById: function () {
 			return _state.teamsById;
 		},
@@ -137,6 +144,10 @@
 					this.removeTeamById(oldTeamId);
 				}
 			}
+		},
+		setActiveTeamByUserId: function (id) {
+			var team = this.getTeamByUserId(id);
+			return this.setActiveTeamId(team.team_id);
 		},
 		setTeamIcon: function (id, teamIcon) {
 			_state.teamIconsById[id] = _.clone(teamIcon);
@@ -208,8 +219,12 @@
 	// Define our handler for various updates
 	TeamStore.dispatchToken = AppDispatcher.register(function handleAction (action) {
 		if (action.type === ActionTypes.ACTIVATE_TEAM) {
-			console.debug('Setting active team id', {teamId: action.teamId});
-			TeamStore.setActiveTeamId(action.teamId);
+			console.debug('Setting active team', {teamId: action.teamId, userId: action.userId});
+			if (action.teamId !== undefined) {
+				TeamStore.setActiveTeamId(action.teamId);
+			} else {
+				TeamStore.setActiveTeamByUserId(action.userId);
+			}
 			TeamStore.emitChange();
 		} else if (action.type === ActionTypes.ADD_TEAM_REQUESTED) {
 			console.debug('Adding placeholder team');


### PR DESCRIPTION
As mentioned in #116, we were missing support for properly switching teams via "Quick Switcher". This PR repairs that by overriding the method called. In this PR:

- Added override for Quick Switcher's team select
- Updated team store to select team via user id
- Fixes #116 

**Notes:**

As mentioned in #116, we are starting to add more hacks and hacks but have discovered `window.TSSSB` which is how Windows/OS X integrate their clients. We should consider leveraging that over installing hacks on specific components (to be opened in a new issue).

/cc @wlaurance 