### PR TITLE
Added newsletter information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Slack client for Linux. Uses [nw.js][].
 - Tray icon with notifications
 - Multi-team support
 - Watch videos in application
+- [Newsletter to know about updates and new features](#newsletter)
 
 ![Screenshot](docs/screenshot.png)
 
@@ -36,6 +37,12 @@ plaidchat
 ```
 
 `plaidchat` is not created by, affiliated with, or supported by Slack Technologies, Inc.
+
+Newsletter
+==========
+Want to hear about our updates and new features as soon as they happen?
+
+[Sign up for our newsletter!](http://eepurl.com/buEVff)
 
 CLI options
 ===========


### PR DESCRIPTION
As discussed in #111, we are introducing a newsletter for `plaidchat`. We have chosen to set up an account with Mailchimp. In this PR:

- Added documentation about newsletter
    - We discussed a badge but I couldn't find anything to grab and go. If we really want a badge, we can fork my work on https://github.com/gratipay/gratipay-badge

/cc @wlaurance 
