### PR TITLE
Moved from Google Chrome to electron-prebuilt for libffmpegsumo.so

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,19 +133,6 @@ machines. If you run into
 
 Give [Issue #1](https://github.com/plaidchat/plaidchat/issues/1) a look.
 
-Crashing when receiving direct message
---------------------------------------
-We have had multiple reports of `plaidchat` crashing when a direct message is received.
-
-This typically is caused by installing while an older version of Google Chrome is on your machine (we use its `libffmpegsumo.so` for audio bindings).
-
-To fix the issue, perform the following steps:
-
-1. Update your version of Google Chrome to its latest version
-    - For example, if your Google Chrome was installed via `apt`/`dpkg`, then run `apt-get install google-chrome-stable`
-2. Reinstall `plaidchat` to pick up the latest version of `libffmpegsumo.so`
-    - `npm uninstall -g plaidchat && npm install -g plaidchat`
-
 Contributing
 ============
 Interested in contributing? Great, we are always looking for more great people.
@@ -158,7 +145,7 @@ License
 =======
 `plaidchat` is licensed under the [MIT license][].
 
-Upon installation, we may copy `libffmpegsumo.so` from `/opt/google/chrome` (from [ffmpeg][]) into our repository. We are required to mention that this file is licensed under the [GPL license][ffmpeg-license].
+Upon installation, we may copy `libffmpegsumo.so` from `electron-prebuilt` (from [ffmpeg][]) into our repository. We are required to mention that this file is licensed under the [GPL license][ffmpeg-license].
 
 [MIT License]: LICENSE
 [ffmpeg]: http://ffmpeg.org/

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "browserify": "^10.2.4",
     "commander": "^2.8.1",
+    "electron-prebuilt": "~0.30.2",
     "favico.js": "^0.3.8",
     "flux": "^2.0.3",
     "get-uri": "^0.1.3",

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -3,19 +3,9 @@
 set -e
 set -x
 
-# If there is a libffmpegsumo, copy it over
-if test -f /opt/google/chrome/libffmpegsumo.so; then
-	cp /opt/google/chrome/libffmpegsumo.so node_modules/nw/nwjs/libffmpegsumo.so
-elif test -f /opt/google/chrome-beta/libffmpegsumo.so; then
-	cp /opt/google/chrome-beta/libffmpegsumo.so node_modules/nw/nwjs/libffmpegsumo.so
-elif test -f /opt/google/chrome-unstable/libffmpegsumo.so; then
-	cp /opt/google/chrome-unstable/libffmpegsumo.so node_modules/nw/nwjs/libffmpegsumo.so
-elif test -f /usr/lib/chromium/libffmpegsumo.so; then
-	cp /usr/lib/chromium/libffmpegsumo.so node_modules/nw/nwjs/libffmpegsumo.so
-else
-	echo "Couldn't locate libffmpegsumo.so during installation. Audio notifications will be disabled" 1>&2
-	echo "To repair this, please install Google Chrome/Chromium and reinstall \`plaidchat\`" 1>&2
-fi
+# Copy `libffmpegsumo.so` from electron to nw.js
+# DEV: We previously copied from Google Chrome, however they have stopped bundling `libffmpegsumo.so`
+cp node_modules/electron-prebuilt/dist/libffmpegsumo.so node_modules/nw/nwjs/libffmpegsumo.so
 
 # Compile our React for nw.js support
 npm run build


### PR DESCRIPTION
As discussed in #100, Google Chrome is no longer providing a `libffmpegsumo.so`. Since we currently haven't invested in distributing `.deb`/`.rpm` (or any archive), then we cannot provide a prebuilt `libffmpegsumo.so` file. As a result, we are introducing a 100MB hack for a 6MB file (hopefully less bandwidth with gzipping) which downloads `electron-prebuilt` and copies its `libffmpegsumo.so` file.

In this PR:

- Replaced copying from Google Chrome with copying from `electron-prebuilt`
- Updated documentation

/cc @wlaurance 