### PR TITLE
Add desktop file and grunt task to build executables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 tmp/
 .DS_Store
 dist/
+build/
+cache/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,7 +55,9 @@ module.exports = function (grunt) {
 		},
 		copy: {
 			build: {
-				options: { mode: '0755' },
+				options: {
+					mode: '0755'
+				},
 				files: [
 					{
 						src: './node_modules/electron-prebuilt/dist/libffmpegsumo.so',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,5 @@
+var pkg = require('./package.json');
+
 module.exports = function (grunt) {
 	'use strict';
 
@@ -5,6 +7,8 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-contrib-jshint');
 	grunt.loadNpmTasks('grunt-jscs');
 	grunt.loadNpmTasks('grunt-lintspaces');
+	grunt.loadNpmTasks('grunt-nw-builder');
+	grunt.loadNpmTasks('grunt-contrib-copy');
 
 	grunt.initConfig({
 		jshint: {
@@ -26,8 +30,46 @@ module.exports = function (grunt) {
 			options: {
 				editorconfig: '.editorconfig'
 			}
+		},
+		nwjs: {
+			build: {
+				options: {
+					platforms: ['linux'],
+					buildDir: './build',
+					version: pkg.dependencies.nw.replace(/[^\d.]+/g, '')
+				},
+				src: [
+					'./package.json',
+					'./dist/**/*',
+					'./app/**/*',
+					'./node_modules/**/*',
+					'!./node_modules/nw/**',
+					'!./node_modules/grunt*/**',
+					'!./node_modules/mocha/**',
+					'!./node_modules/webdriver-manager/**',
+					'!./node_modules/electron-prebuild/**',
+					'!./node_modules/wd/**',
+					'!./node_modules/chai/**'
+				]
+			}
+		},
+		copy: {
+			build: {
+				options: { mode: '0755' },
+				files: [
+					{
+						src: './node_modules/electron-prebuilt/dist/libffmpegsumo.so',
+						dest: './build/plaidchat/linux64/libffmpegsumo.so'
+					},
+					{
+						src: './node_modules/electron-prebuilt/dist/libffmpegsumo.so',
+						dest: './build/plaidchat/linux32/libffmpegsumo.so'
+					}
+				]
+			}
 		}
 	});
 
 	grunt.registerTask('lint', ['jshint', 'jscs', 'lintspaces']);
+	grunt.registerTask('build', ['nwjs:build', 'copy:build']);
 };

--- a/package.json
+++ b/package.json
@@ -58,9 +58,11 @@
     "github-changes": "^1.0.0",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
+    "grunt-contrib-copy": "^0.8.1",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-jscs": "^1.1.0",
     "grunt-lintspaces": "^0.6.0",
+    "grunt-nw-builder": "^2.0.0",
     "mocha": "^2.2.5",
     "wd": "^0.3.12",
     "webdriver-manager": "^7.0.1"

--- a/plaidchat.desktop
+++ b/plaidchat.desktop
@@ -8,4 +8,3 @@ Terminal=false
 Type=Application
 Categories=Network;Chat;
 Keywords=slack;plaidchat;chat;instant-messaging;
-

--- a/plaidchat.desktop
+++ b/plaidchat.desktop
@@ -1,0 +1,11 @@
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+Name=Plaidchat
+Comment=A Slack Interface for Linux
+Icon=slack
+Exec=plaidchat
+Terminal=false
+Type=Application
+Categories=Network;Chat;
+Keywords=slack;plaidchat;chat;instant-messaging;
+


### PR DESCRIPTION
This PR is an attempt to simply the process of creating packages for native Linux package managers.

Added a desktop file entry as discussed in #102.

I also added a Grunt task to build the app with `node-webkit`. This task will allow for:
- reuse of `node-webkit` if they already have it installed from the AUR (or any other package repository)
- take up less disk space by building the executable with only what's needed instead of the whole repo
