### PR TITLE
Fixed lint targets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function (grunt) {
 
 	grunt.initConfig({
 		jshint: {
-			all: ['*.js', 'app/js/*.js', 'test/**/*.js'],
+			all: ['*.js', 'app/**/*.js', 'test/**/*.js'],
 			jshintrc: '.jshintrc'
 		},
 		jscs: {


### PR DESCRIPTION
When we moved from vanilla JS to React, it looks like we never updated our lint rules to cover other files. In this PR:

- Corrected lint rules to lint every JS file in `app/`

/cc @wlaurance 