### PR TITLE
Context menu enhancements

### DIFF
--- a/app/components/slack-window.js
+++ b/app/components/slack-window.js
@@ -44,7 +44,13 @@
 			var that = this;
 
 			win.addEventListener('contextmenu', function handleContextMenu (evt) {
-				SlackContextMenu.handleRightClick(that.getWindow(), evt.target, evt.x, evt.y);
+				SlackContextMenu.handleRightClick({
+					target: evt.target,
+					teamUrl: that.props.team.team_url,
+					window: that.getWindow(),
+					x: evt.x,
+					y: evt.y
+				});
 			});
 
 			win.addEventListener('click', function handleClick (evt) {


### PR DESCRIPTION
Thanks @justinnichols for providing the context menu with more structure and in cleaner fashion than what I had hacked together in https://github.com/mathieumg/plaidchat/commit/b47e6285f109a13a2c3e1c0b75b33ef809413966

However, there are a couple things I thought were worth salvaging:

* Hyperlinks can be many things, they should not be limited to HTTP/HTTPS and absolute URLs. I removed the `http`/`https` check and replaced it with a check that prepends the current team's URL if the link is relative to the domain. (i.e. starts with `/`) Since `slack-context-menu` is used entirely statically, I had to pass along the team URL when calling its `handleRightClick` method. 
* To be more in line with the official Slack client, I added the ability to copy an hyperlink and renamed the menu options to "Copy Link" and "Open Link". I can provide a screenshot from the Windows client if you want.

This now allows, for example, to copy/open "ftp://" URLs and more importantly copy/open permalinks to messages, which is something I personally use a lot to quote previous messages. Both of these work that way in the official client.

I didn't squash the changes yet as I thought you might not want all of them, so let me know.