### PR TITLE
Moved to require.resolve for finding libffmpegsumo.so src and target

### DIFF
--- a/postinstall.sh
+++ b/postinstall.sh
@@ -5,7 +5,11 @@ set -x
 
 # Copy `libffmpegsumo.so` from electron to nw.js
 # DEV: We previously copied from Google Chrome, however they have stopped bundling `libffmpegsumo.so`
-cp node_modules/electron-prebuilt/dist/libffmpegsumo.so node_modules/nw/nwjs/libffmpegsumo.so
+# Example: `node_modules/electron-prebuilt/dist/libffmpegsumo.so`
+libffmpegsumo_src_path="$(node --eval "console.log(require.resolve('electron-prebuilt/dist/libffmpegsumo.so'))")"
+# Example: `node_modules/nwjs/libffmpegsumo.so`
+libffmpegsumo_target_path="$(node --eval "console.log(require('path').normalize(require.resolve('nw/nwjs/nw') + '/../libffmpegsumo.so'))")"
+cp "$libffmpegsumo_src_path" "$libffmpegsumo_target_path"
 
 # Compile our React for nw.js support
 npm run build


### PR DESCRIPTION
Some users have reported installation issues due to `cp` assuming modules are located in `node_modules/`. To resolve this issue, we are moving to `require.resolve` which is how Node.js resolves modules.

In this PR:

- Updated script to resolve src and target paths via `require.resolve`

/cc @wlaurance 